### PR TITLE
Allow setting seek position in play function

### DIFF
--- a/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
+++ b/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
@@ -53,8 +53,10 @@ public class AudioplayersPlugin implements MethodCallHandler {
             case "play": {
                 final String url = call.argument("url");
                 final double volume = call.argument("volume");
+                final double position = call.argument("position");
                 player.setUrl(url);
                 player.setVolume(volume);
+                player.seek(position);
                 player.play();
                 break;
             }
@@ -75,7 +77,7 @@ public class AudioplayersPlugin implements MethodCallHandler {
                 break;
             }
             case "seek": {
-                double position = call.argument("position");
+                final double position = call.argument("position");
                 player.seek(position);
                 break;
             }

--- a/example/lib/player_widget.dart
+++ b/example/lib/player_widget.dart
@@ -140,13 +140,13 @@ class _PlayerWidgetState extends State<PlayerWidget> {
   }
 
   Future<int> _play() async {
-    final startPosition = (_position != null
+    final playPosition = (_position != null
         && _duration != null
         && _position.inMilliseconds > 0
         && _position.inMilliseconds < _duration.inMilliseconds)
         ? _position
         : Duration.zero;
-    final result = await _audioPlayer.play(url, isLocal: isLocal, position: startPosition);
+    final result = await _audioPlayer.play(url, isLocal: isLocal, position: playPosition);
     if (result == 1) setState(() => _playerState = PlayerState.playing);
     return result;
   }

--- a/example/lib/player_widget.dart
+++ b/example/lib/player_widget.dart
@@ -140,7 +140,13 @@ class _PlayerWidgetState extends State<PlayerWidget> {
   }
 
   Future<int> _play() async {
-    final result = await _audioPlayer.play(url, isLocal: isLocal);
+    final startPosition = (_position != null
+        && _duration != null
+        && _position.inMilliseconds > 0
+        && _position.inMilliseconds < _duration.inMilliseconds)
+        ? _position
+        : Duration.zero;
+    final result = await _audioPlayer.play(url, isLocal: isLocal, position: startPosition);
     if (result == 1) setState(() => _playerState = PlayerState.playing);
     return result;
   }

--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -60,11 +60,16 @@ FlutterMethodChannel *_channel_audioplayer;
                       result(0);
                     if (call.arguments[@"volume"]==nil)
                       result(0);
+                    if (call.arguments[@"position"]==nil)
+                      result(0);
                     int isLocal = [call.arguments[@"isLocal"]intValue] ;
                     float volume = (float)[call.arguments[@"volume"] doubleValue] ;
+                    double seconds = [call.arguments[@"position"] doubleValue] ;
+                    CMTime time = CMTimeMakeWithSeconds(seconds,1);
                     NSLog(@"isLocal: %d %@",isLocal, call.arguments[@"isLocal"] );
                     NSLog(@"volume: %f %@",volume, call.arguments[@"volume"] );
-                    [self play:playerId url:url isLocal:isLocal volume:volume];
+                    NSLog(@"position: %f %@", seconds, call.arguments[@"positions"] );
+                    [self play:playerId url:url isLocal:isLocal volume:volume time:time];
                   },
                 @"pause":
                   ^{
@@ -217,6 +222,7 @@ FlutterMethodChannel *_channel_audioplayer;
          url: (NSString*) url
      isLocal: (int) isLocal
       volume: (float) volume
+        time: (CMTime) time
 {
   NSError *error = nil;
   BOOL success = [[AVAudioSession sharedInstance]
@@ -234,6 +240,7 @@ FlutterMethodChannel *_channel_audioplayer;
            NSMutableDictionary * playerInfo = players[playerId];
            AVPlayer *player = playerInfo[@"player"];
            [ player setVolume:volume ];
+           [ player seekToTime:time ];
            [ player play];
            [ playerInfo setObject:@true forKey:@"isPlaying" ];
          }    

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -82,9 +82,11 @@ class AudioPlayer {
   }
 
   /// Play audio. Url can be a remote url (isLocal = false) or a local file system path (isLocal = true).
-  Future<int> play(String url, {bool isLocal: false, double volume: 1.0}) {
+  Future<int> play(String url, {bool isLocal: false, double volume: 1.0, Duration position: Duration.zero}) {
+    double positionInSeconds =
+        position.inMicroseconds / Duration.microsecondsPerSecond;
     return _invokeMethod(
-        'play', {'url': url, 'isLocal': isLocal, 'volume': volume});
+        'play', {'url': url, 'isLocal': isLocal, 'volume': volume, 'position': positionInSeconds});
   }
 
   /// Pause the currently playing audio (resumes from this point).


### PR DESCRIPTION
Currently audio files must start playing from the beginning. This PR adds the optional functionality of setting the playback position to the `play` function (calls `seek` during player setup calling `play`).