### PR TITLE
Fix duration changes being broadcast on position change stream

### DIFF
--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -240,7 +240,7 @@ class AudioPlayer {
     switch (call.method) {
       case 'audio.onDuration':
         Duration newDuration = new Duration(milliseconds: value);
-        player._positionController.add(newDuration);
+        player._durationController.add(newDuration);
         if (player.durationHandler != null) {
           player.durationHandler(newDuration);
         }


### PR DESCRIPTION
Changes to the current duration are broadcast to the position change stream, rather than to the duration change stream. 

This should fix that.