### PR TITLE
Improve `dispose()` method.

### DIFF
--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -395,11 +395,14 @@ class AudioPlayer {
   ///
   /// You must call this method when your [AudioPlayer] instance is not going to
   /// be used anymore.
-  dispose() {
-    if (!_playerStateController.isClosed) _playerStateController.close();
-    if (!_positionController.isClosed) _positionController.close();
-    if (!_durationController.isClosed) _durationController.close();
-    if (!_completionController.isClosed) _completionController.close();
-    if (!_errorController.isClosed) _errorController.close();
-  }
+  Future<void> dispose() async {
+    List<Future> futures = [];
+
+    if (!_playerStateController.isClosed) futures.add(_playerStateController.close());
+    if (!_positionController.isClosed) futures.add(_positionController.close());
+    if (!_durationController.isClosed) futures.add(_durationController.close());
+    if (!_completionController.isClosed) futures.add(_completionController.close());
+    if (!_errorController.isClosed) futures.add(_errorController.close());
+
+  await Future.wait(futures);
 }


### PR DESCRIPTION
A while ago I sent #168, adding the `dispose()` method. Today I realized my change was pretty incondite, since I did not annotate the return type and did not wait for the `StreamController`s to close. With this PR I'm fixing it.

Please notice that `StreamController.close()` will never complete if no one is listening to its stream, however this does not proceed for `BroadcastStreamController`s, which you are using, so there should be no concerns. I'm emphasizing this so you are aware of possible problems in case you decide to not use `BroadcastStream`s anymore.