### PR TITLE
added respect audio focus feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ If you want to play audio for a long period of time, you need to set appropriate
 If you pass `setAwake` as true you need to add this permission to your app manifest: 
 `<uses-permission android:name="android.permission.WAKE_LOCK" />`.
 
+If you want your audio player to pause when interrupted by other apps that produce audio (like youtube, Instagram, etc`), 
+then you need to set appropriately the flag `respectAudioFocus`. If the app is interrupted by an app with long duration audio then your audio player will pause, but if interrupted by an app with short duration audio it will pause until audio of that particular app stops and then resume your audio player.
+
 ```dart
   play() async {
     int result = await audioPlayer.play(url);

--- a/android/src/main/java/xyz/luan/audioplayers/Player.java
+++ b/android/src/main/java/xyz/luan/audioplayers/Player.java
@@ -21,7 +21,7 @@ abstract class Player {
 
     abstract void setVolume(double volume);
 
-    abstract void configAttributes(boolean respectSilence, boolean stayAwake, Context context);
+    abstract void configAttributes(boolean respectSilence, boolean stayAwake, Context context, boolean isRespectingAudioFocus);
 
     abstract void setReleaseMode(ReleaseMode releaseMode);
 
@@ -31,6 +31,7 @@ abstract class Player {
 
     abstract boolean isActuallyPlaying();
 
+    abstract boolean isRespectingAudioFocus();
     /**
      * Seek operations cannot be called until after the player is ready.
      */

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
@@ -17,6 +17,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
     private double volume = 1.0;
     private boolean respectSilence;
     private boolean stayAwake;
+    private boolean isRespectingAudioFocus;
     private ReleaseMode releaseMode = ReleaseMode.RELEASE;
 
     private boolean released = true;
@@ -67,7 +68,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
     }
 
     @Override
-    void configAttributes(boolean respectSilence, boolean stayAwake, Context context) {
+    void configAttributes(boolean respectSilence, boolean stayAwake, Context context, boolean isRespectingAudioFocus) {
         if (this.respectSilence != respectSilence) {
             this.respectSilence = respectSilence;
             if (!this.released) {
@@ -78,6 +79,11 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
             this.stayAwake = stayAwake;
             if (!this.released && this.stayAwake) {
                 this.player.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK);
+            }
+        }
+        if(this.isRespectingAudioFocus != isRespectingAudioFocus){
+            if (!this.released) {
+                this.isRespectingAudioFocus = isRespectingAudioFocus;
             }
         }
     }
@@ -116,6 +122,11 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
         return this.playing && this.prepared;
     }
 
+    @Override
+    boolean isRespectingAudioFocus() {
+        return this.isRespectingAudioFocus;
+    }
+    
     /**
      * Playback handling methods
      */

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
@@ -115,7 +115,7 @@ public class WrappedSoundPool extends Player implements SoundPool.OnLoadComplete
     }
 
     @Override
-    void configAttributes(boolean respectSilence, boolean setWakeMode, Context context) {
+    void configAttributes(boolean respectSilence, boolean setWakeMode, Context context, boolean isRespectingAudioFocus) {
     }
 
     @Override
@@ -146,6 +146,11 @@ public class WrappedSoundPool extends Player implements SoundPool.OnLoadComplete
         throw unsupportedOperation("seek");
     }
 
+    @Override
+    boolean isRespectingAudioFocus() {
+        return false;
+    }
+    
     private static SoundPool createSoundPool() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             AudioAttributes attrs = new AudioAttributes.Builder().setLegacyStreamType(AudioManager.USE_DEFAULT_STREAM_TYPE)

--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -94,7 +94,8 @@ class AudioCache {
       {double volume = 1.0,
       bool isNotification,
       PlayerMode mode = PlayerMode.MEDIA_PLAYER,
-      bool stayAwake}) async {
+      bool stayAwake,
+      bool respectAudioFocus}) async {
     File file = await load(fileName);
     AudioPlayer player = _player(mode);
     await player.play(
@@ -103,6 +104,7 @@ class AudioCache {
       volume: volume,
       respectSilence: isNotification ?? respectSilence,
       stayAwake: stayAwake,
+          respectAudioFocus: respectAudioFocus,
     );
     return player;
   }

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -224,11 +224,13 @@ class AudioPlayer {
     Duration position,
     bool respectSilence = false,
     bool stayAwake = false,
+    bool respectAudioFocus = false,
   }) async {
     isLocal ??= false;
     volume ??= 1.0;
     respectSilence ??= false;
     stayAwake ??= false;
+    respectAudioFocus ??= false;
 
     final int result = await _invokeMethod('play', {
       'url': url,
@@ -237,6 +239,7 @@ class AudioPlayer {
       'position': position?.inMilliseconds,
       'respectSilence': respectSilence,
       'stayAwake': stayAwake,
+      'respectAudioFocus': respectAudioFocus,
     });
 
     if (result == 1) {


### PR DESCRIPTION
respect audio focus feature lets your audio player detect when interrupted by other apps that also produce audio (like youtube, Instagram, etc`), and If the app is interrupted by an app with long duration audio then your audio player will pause, but if interrupted by an app with short duration audio it will pause until audio of that particular app stops and then resume your audio player.

I built this feature using Audio Focus Change Listener with audio manager request Audio Focus.
I know you don't have this feature for ios but I hope you add it for android and later someone (maybe me) would make this feature for ios also.