### PR TITLE
Implement onSeekComplete stream/handler for android

### DIFF
--- a/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
+++ b/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
@@ -23,6 +23,7 @@ public class AudioplayersPlugin implements MethodCallHandler {
     private final Handler handler = new Handler();
     private Runnable positionUpdates;
     private final Activity activity;
+    private boolean seekFinish;
 
     public static void registerWith(final Registrar registrar) {
         final MethodChannel channel = new MethodChannel(registrar.messenger(), "xyz.luan/audioplayers");
@@ -33,6 +34,7 @@ public class AudioplayersPlugin implements MethodCallHandler {
         this.channel = channel;
         this.channel.setMethodCallHandler(this);
         this.activity = activity;
+        this.seekFinish = false;
     }
 
     @Override
@@ -144,6 +146,11 @@ public class AudioplayersPlugin implements MethodCallHandler {
         channel.invokeMethod("audio.onComplete", buildArguments(player.getPlayerId(), true));
     }
 
+    public void handleSeekComplete(Player player) {
+        //channel.invokeMethod("audio.onSeekComplete", buildArguments(player.getPlayerId(), true));
+        this.seekFinish = true;
+    }
+
     private void startPositionUpdates() {
         if (positionUpdates != null) {
             return;
@@ -207,7 +214,11 @@ public class AudioplayersPlugin implements MethodCallHandler {
                     final int time = player.getCurrentPosition();
                     channel.invokeMethod("audio.onDuration", buildArguments(key, duration));
                     channel.invokeMethod("audio.onCurrentPosition", buildArguments(key, time));
-                } catch(UnsupportedOperationException e) {
+                    if (audioplayersPlugin.seekFinish) {
+                        channel.invokeMethod("audio.onSeekComplete", buildArguments(player.getPlayerId(), true));
+                        audioplayersPlugin.seekFinish = false;
+                    }
+                } catch (UnsupportedOperationException e) {
 
                 }
             }
@@ -220,3 +231,4 @@ public class AudioplayersPlugin implements MethodCallHandler {
         }
     }
 }
+

--- a/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
+++ b/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
@@ -147,7 +147,6 @@ public class AudioplayersPlugin implements MethodCallHandler {
     }
 
     public void handleSeekComplete(Player player) {
-        //channel.invokeMethod("audio.onSeekComplete", buildArguments(player.getPlayerId(), true));
         this.seekFinish = true;
     }
 

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
@@ -9,7 +9,7 @@ import android.content.Context;
 
 import java.io.IOException;
 
-public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPreparedListener, MediaPlayer.OnCompletionListener {
+public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPreparedListener, MediaPlayer.OnCompletionListener, MediaPlayer.OnSeekCompleteListener {
 
     private String playerId;
 
@@ -215,6 +215,11 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
         ref.handleCompletion(this);
     }
 
+    @Override
+    public void onSeekComplete(final MediaPlayer mediaPlayer) {
+        ref.handleSeekComplete(this);
+    }
+
     /**
      * Internal logic. Private methods
      */
@@ -223,6 +228,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
         MediaPlayer player = new MediaPlayer();
         player.setOnPreparedListener(this);
         player.setOnCompletionListener(this);
+        player.setOnSeekCompleteListener(this);
         setAttributes(player);
         player.setVolume((float) volume, (float) volume);
         player.setLooping(this.releaseMode == ReleaseMode.LOOP);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:provider/provider.dart';
 
 import 'player_widget.dart';
 
@@ -42,24 +43,9 @@ class _ExampleAppState extends State<ExampleApp> {
     }
   }
 
-  Widget _tab(List<Widget> children) {
-    return Center(
-      child: Container(
-        padding: EdgeInsets.all(16.0),
-        child: Column(
-          children: children.map((w) => Container(child: w, padding: EdgeInsets.all(6.0))).toList(),
-        ),
-      ),
-    );
-  }
-
-  Widget _btn(String txt, VoidCallback onPressed) {
-    return ButtonTheme(minWidth: 48.0, child: RaisedButton(child: Text(txt), onPressed: onPressed));
-  }
-
   Widget remoteUrl() {
     return SingleChildScrollView(
-      child: _tab([
+      child: _tab(children: [
         Text(
           'Sample 1 ($kUrl1)',
           style: TextStyle(fontWeight: FontWeight.bold),
@@ -85,26 +71,34 @@ class _ExampleAppState extends State<ExampleApp> {
   }
 
   Widget localFile() {
-    return _tab([
+    return _tab(children: [
       Text('File: $kUrl1'),
-      _btn('Download File to your Device', () => _loadFile()),
+      _btn(txt: 'Download File to your Device', onPressed: () => _loadFile()),
       Text('Current local file path: $localFilePath'),
-      localFilePath == null ? Container() : PlayerWidget(url: localFilePath, isLocal: true),
+      localFilePath == null
+          ? Container()
+          : PlayerWidget(url: localFilePath, isLocal: true),
     ]);
   }
 
   Widget localAsset() {
-    return _tab([
+    return _tab(children: [
       Text('Play Local Asset \'audio.mp3\':'),
-      _btn('Play', () => audioCache.play('audio.mp3')),
+      _btn(txt: 'Play', onPressed: () => audioCache.play('audio.mp3')),
       Text('Loop Local Asset \'audio.mp3\':'),
-      _btn('Loop', () => audioCache.loop('audio.mp3')),
+      _btn(txt: 'Loop', onPressed: () => audioCache.loop('audio.mp3')),
       Text('Play Local Asset \'audio2.mp3\':'),
-      _btn('Play', () => audioCache.play('audio2.mp3')),
+      _btn(txt: 'Play', onPressed: () => audioCache.play('audio2.mp3')),
       Text('Play Local Asset In Low Latency \'audio.mp3\':'),
-      _btn('Play', () => audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY)),
+      _btn(
+          txt: 'Play',
+          onPressed: () =>
+              audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY)),
       Text('Play Local Asset In Low Latency \'audio2.mp3\':'),
-      _btn('Play', () => audioCache.play('audio2.mp3', mode: PlayerMode.LOW_LATENCY)),
+      _btn(
+          txt: 'Play',
+          onPressed: () =>
+              audioCache.play('audio2.mp3', mode: PlayerMode.LOW_LATENCY)),
       getLocalFileDuration(),
     ]);
   }
@@ -115,7 +109,8 @@ class _ExampleAppState extends State<ExampleApp> {
       audiofile.path,
       isLocal: true,
     );
-    int duration = await Future.delayed(Duration(seconds: 2), () => advancedPlayer.getDuration());
+    int duration = await Future.delayed(
+        Duration(seconds: 2), () => advancedPlayer.getDuration());
     return duration;
   }
 
@@ -131,7 +126,8 @@ class _ExampleAppState extends State<ExampleApp> {
             return Text('Awaiting result...');
           case ConnectionState.done:
             if (snapshot.hasError) return Text('Error: ${snapshot.error}');
-            return Text('audio2.mp3 duration is: ${Duration(milliseconds: snapshot.data)}');
+            return Text(
+                'audio2.mp3 duration is: ${Duration(milliseconds: snapshot.data)}');
         }
         return null; // unreachable
       },
@@ -139,81 +135,216 @@ class _ExampleAppState extends State<ExampleApp> {
   }
 
   Widget notification() {
-    return _tab([
+    return _tab(children: [
       Text('Play notification sound: \'messenger.mp3\':'),
-      _btn('Play', () => audioCache.play('messenger.mp3', isNotification: true)),
-    ]);
-  }
-
-  Widget advanced() {
-    return _tab([
-      Column(children: [
-        Text('Source Url'),
-        Row(children: [
-          _btn('Audio 1', () => advancedPlayer.setUrl(kUrl1)),
-          _btn('Audio 2', () => advancedPlayer.setUrl(kUrl2)),
-          _btn('Stream', () => advancedPlayer.setUrl(kUrl3)),
-        ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
-      ]),
-      Column(children: [
-        Text('Release Mode'),
-        Row(children: [
-          _btn('STOP', () => advancedPlayer.setReleaseMode(ReleaseMode.STOP)),
-          _btn('LOOP', () => advancedPlayer.setReleaseMode(ReleaseMode.LOOP)),
-          _btn('RELEASE', () => advancedPlayer.setReleaseMode(ReleaseMode.RELEASE)),
-        ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
-      ]),
-      new Column(children: [
-        Text('Volume'),
-        Row(children: [
-          _btn('0.0', () => advancedPlayer.setVolume(0.0)),
-          _btn('0.5', () => advancedPlayer.setVolume(0.5)),
-          _btn('1.0', () => advancedPlayer.setVolume(1.0)),
-          _btn('2.0', () => advancedPlayer.setVolume(2.0)),
-        ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
-      ]),
-      new Column(children: [
-        Text('Control'),
-        Row(children: [
-          _btn('resume', () => advancedPlayer.resume()),
-          _btn('pause', () => advancedPlayer.pause()),
-          _btn('stop', () => advancedPlayer.stop()),
-          _btn('release', () => advancedPlayer.release()),
-        ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
-      ]),
-      new Column(children: [
-        Text('Seek in milliseconds'),
-        Row(children: [
-          _btn('100ms', () => advancedPlayer.seek(Duration(milliseconds: 100))),
-          _btn('500ms', () => advancedPlayer.seek(Duration(milliseconds: 500))),
-          _btn('1s', () => advancedPlayer.seek(Duration(seconds: 1))),
-          _btn('1.5s', () => advancedPlayer.seek(Duration(milliseconds: 1500))),
-        ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
-      ]),
+      _btn(
+          txt: 'Play',
+          onPressed: () =>
+              audioCache.play('messenger.mp3', isNotification: true)),
     ]);
   }
 
   @override
   Widget build(BuildContext context) {
-    return DefaultTabController(
-      length: 5,
-      child: Scaffold(
-        appBar: AppBar(
-          bottom: TabBar(
-            tabs: [
-              Tab(text: 'Remote Url'),
-              Tab(text: 'Local File'),
-              Tab(text: 'Local Asset'),
-              Tab(text: 'Notification'),
-              Tab(text: 'Advanced'),
+    return MultiProvider(
+      providers: [
+        StreamProvider<Duration>.value(
+            initialData: Duration(),
+            value: advancedPlayer.onAudioPositionChanged),
+      ],
+      child: DefaultTabController(
+        length: 5,
+        child: Scaffold(
+          appBar: AppBar(
+            bottom: TabBar(
+              tabs: [
+                Tab(text: 'Remote Url'),
+                Tab(text: 'Local File'),
+                Tab(text: 'Local Asset'),
+                Tab(text: 'Notification'),
+                Tab(text: 'Advanced'),
+              ],
+            ),
+            title: Text('audioplayers Example'),
+          ),
+          body: TabBarView(
+            children: [
+              remoteUrl(),
+              localFile(),
+              localAsset(),
+              notification(),
+              Advanced(
+                advancedPlayer: advancedPlayer,
+              )
             ],
           ),
-          title: Text('audioplayers Example'),
-        ),
-        body: TabBarView(
-          children: [remoteUrl(), localFile(), localAsset(), notification(), advanced()],
         ),
       ),
     );
+  }
+}
+
+class Advanced extends StatefulWidget {
+  final AudioPlayer advancedPlayer;
+
+  const Advanced({Key key, this.advancedPlayer}) : super(key: key);
+
+  @override
+  _AdvancedState createState() => _AdvancedState();
+}
+
+class _AdvancedState extends State<Advanced> {
+  bool seekDone;
+
+  @override
+  void initState() {
+    widget.advancedPlayer.seekCompleteHandler =
+        () => setState(() => seekDone = true);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final audioPosition = Provider.of<Duration>(context);
+    return _tab(
+      children: [
+        Column(children: [
+          Text('Source Url'),
+          Row(children: [
+            _btn(
+                txt: 'Audio 1',
+                onPressed: () => widget.advancedPlayer.setUrl(kUrl1)),
+            _btn(
+                txt: 'Audio 2',
+                onPressed: () => widget.advancedPlayer.setUrl(kUrl2)),
+            _btn(
+                txt: 'Stream',
+                onPressed: () => widget.advancedPlayer.setUrl(kUrl3)),
+          ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
+        ]),
+        Column(children: [
+          Text('Release Mode'),
+          Row(children: [
+            _btn(
+                txt: 'STOP',
+                onPressed: () =>
+                    widget.advancedPlayer.setReleaseMode(ReleaseMode.STOP)),
+            _btn(
+                txt: 'LOOP',
+                onPressed: () =>
+                    widget.advancedPlayer.setReleaseMode(ReleaseMode.LOOP)),
+            _btn(
+                txt: 'RELEASE',
+                onPressed: () =>
+                    widget.advancedPlayer.setReleaseMode(ReleaseMode.RELEASE)),
+          ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
+        ]),
+        new Column(children: [
+          Text('Volume'),
+          Row(children: [
+            _btn(
+                txt: '0.0',
+                onPressed: () => widget.advancedPlayer.setVolume(0.0)),
+            _btn(
+                txt: '0.5',
+                onPressed: () => widget.advancedPlayer.setVolume(0.5)),
+            _btn(
+                txt: '1.0',
+                onPressed: () => widget.advancedPlayer.setVolume(1.0)),
+            _btn(
+                txt: '2.0',
+                onPressed: () => widget.advancedPlayer.setVolume(2.0)),
+          ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
+        ]),
+        new Column(children: [
+          Text('Control'),
+          Row(children: [
+            _btn(
+                txt: 'resume', onPressed: () => widget.advancedPlayer.resume()),
+            _btn(txt: 'pause', onPressed: () => widget.advancedPlayer.pause()),
+            _btn(txt: 'stop', onPressed: () => widget.advancedPlayer.stop()),
+            _btn(
+                txt: 'release',
+                onPressed: () => widget.advancedPlayer.release()),
+          ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
+        ]),
+        new Column(
+          children: [
+            Text('Seek in milliseconds'),
+            Row(children: [
+              _btn(
+                  txt: '100ms',
+                  onPressed: () {
+                    widget.advancedPlayer.seek(Duration(
+                        milliseconds: audioPosition.inMilliseconds + 100));
+                    setState(() => seekDone = false);
+                  }),
+              _btn(
+                  txt: '500ms',
+                  onPressed: () {
+                    widget.advancedPlayer.seek(Duration(
+                        milliseconds: audioPosition.inMilliseconds + 500));
+                    setState(() => seekDone = false);
+                  }),
+              _btn(
+                  txt: '1s',
+                  onPressed: () {
+                    widget.advancedPlayer
+                        .seek(Duration(seconds: audioPosition.inSeconds + 1));
+                    setState(() => seekDone = false);
+                  }),
+              _btn(
+                  txt: '1.5s',
+                  onPressed: () {
+                    widget.advancedPlayer.seek(Duration(
+                        milliseconds: audioPosition.inMilliseconds + 1500));
+                    setState(() => seekDone = false);
+                  }),
+            ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
+            Text('Audio Position: ${audioPosition}'),
+            seekDone == null
+                ? SizedBox(
+                    width: 0,
+                    height: 0,
+                  )
+                : Text(seekDone ? "Seek Done" : "Seeking..."),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _tab extends StatelessWidget {
+  final List<Widget> children;
+
+  const _tab({Key key, this.children}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        padding: EdgeInsets.all(16.0),
+        child: Column(
+          children: children
+              .map((w) => Container(child: w, padding: EdgeInsets.all(6.0)))
+              .toList(),
+        ),
+      ),
+    );
+  }
+}
+
+class _btn extends StatelessWidget {
+  final String txt;
+  final VoidCallback onPressed;
+
+  const _btn({Key key, this.txt, this.onPressed}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ButtonTheme(
+        minWidth: 48.0,
+        child: RaisedButton(child: Text(txt), onPressed: onPressed));
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   path_provider: ^1.1.0
   audioplayers:
     path: ../
-
+  provider: ^3.0.0+1
 flutter:
   uses-material-design: true
 

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -84,6 +84,9 @@ class AudioPlayer {
   final StreamController<void> _completionController =
       StreamController<void>.broadcast();
 
+  final StreamController<void> _seekCompleteController =
+  StreamController<void>.broadcast();
+
   final StreamController<String> _errorController =
       StreamController<String>.broadcast();
 
@@ -133,6 +136,11 @@ class AudioPlayer {
   /// [ReleaseMode.LOOP] also sends events to this stream.
   Stream<void> get onPlayerCompletion => _completionController.stream;
 
+  /// Stream of seek completions.
+  ///
+  /// An event is going to be sent as soon as the audio seek is finished.
+  Stream<void> get onSeekComplete => _seekCompleteController.stream;
+
   /// Stream of player errors.
   ///
   /// Events are sent when an unexpected error is thrown in the native code.
@@ -172,6 +180,14 @@ class AudioPlayer {
   /// This is deprecated. Use [onPlayerCompletion] instead.
   @deprecated
   VoidCallback completionHandler;
+
+  /// Handler of seek completion.
+  ///
+  /// An event is going to be sent as soon as the audio seek is finished.
+  ///
+  /// This is deprecated. Use [onSeekComplete] instead.
+  @deprecated
+  VoidCallback seekCompleteHandler;
 
   /// Handler of player errors.
   ///
@@ -382,6 +398,10 @@ class AudioPlayer {
         // ignore: deprecated_member_use_from_same_package
         player.completionHandler?.call();
         break;
+      case 'audio.onSeekComplete':
+        player._seekCompleteController.add(null);
+        player.seekCompleteHandler?.call();
+        break;
       case 'audio.onError':
         player.state = AudioPlayerState.STOPPED;
         player._errorController.add(value);
@@ -412,6 +432,7 @@ class AudioPlayer {
     if (!_durationController.isClosed) futures.add(_durationController.close());
     if (!_completionController.isClosed)
       futures.add(_completionController.close());
+    if (!_seekCompleteController.isClosed) futures.add(_seekCompleteController.close());
     if (!_errorController.isClosed) futures.add(_errorController.close());
 
     await Future.wait(futures);


### PR DESCRIPTION
As for android media player, it says:

>  Although the asynchronuous seekTo(long, int) call returns right away, the actual seek operation may take a while to finish, especially for audio/video being streamed. When the actual seek operation completes, the internal player engine calls a user supplied OnSeekComplete.onSeekComplete() if an OnSeekCompleteListener has been registered beforehand via setOnSeekCompleteListener(android.media.MediaPlayer.OnSeekCompleteListener).

The background is that, I'm using your plguin to implement some podcast app (thank you for this awesome plugin!). I made a progress bar (listens to `onAudioPositionChanged` stream) and a seek thumb (listens to a stream with combineLatest2 on `onAudioPositionChanged` and a custom stream that's changed on user tab, with the latter take precedence). Once user release seek thumb, i call `seek()` and feed the custom stream to null, however, in this case because seek has not completed, user will suffer the seek thumb *ping-pong* hassel.

Since I'm not ios developer and only a 1/10 x android developer (instead of 10x), i just follow your pattern to implement android host code.

The reason I put the `invokeMethod` in `UpdateCallback`, instead of directly in `handleSeekComplete` is that i have to serialize the audio position change and seek finish event. Otherwise, the issue i mentioned above remains, since both events are called back in parallel.