### PR TITLE
Support for registering plugin in background enviroment

### DIFF
--- a/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
+++ b/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
@@ -1,7 +1,7 @@
 package xyz.luan.audioplayers;
 
+import android.content.Context;
 import android.os.Handler;
-import android.app.Activity;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
@@ -22,18 +22,18 @@ public class AudioplayersPlugin implements MethodCallHandler {
     private final Map<String, Player> mediaPlayers = new HashMap<>();
     private final Handler handler = new Handler();
     private Runnable positionUpdates;
-    private final Activity activity;
+    private final Context context;
     private boolean seekFinish;
 
     public static void registerWith(final Registrar registrar) {
         final MethodChannel channel = new MethodChannel(registrar.messenger(), "xyz.luan/audioplayers");
-        channel.setMethodCallHandler(new AudioplayersPlugin(channel, registrar.activity()));
+        channel.setMethodCallHandler(new AudioplayersPlugin(channel, registrar.activeContext()));
     }
 
-    private AudioplayersPlugin(final MethodChannel channel, Activity activity) {
+    private AudioplayersPlugin(final MethodChannel channel, Context context) {
         this.channel = channel;
         this.channel.setMethodCallHandler(this);
-        this.activity = activity;
+        this.context = context;
         this.seekFinish = false;
     }
 
@@ -59,7 +59,7 @@ public class AudioplayersPlugin implements MethodCallHandler {
                 final boolean respectSilence = call.argument("respectSilence");
                 final boolean isLocal = call.argument("isLocal");
                 final boolean stayAwake = call.argument("stayAwake");
-                player.configAttributes(respectSilence, stayAwake, activity.getApplicationContext());
+                player.configAttributes(respectSilence, stayAwake, context.getApplicationContext());
                 player.setVolume(volume);
                 player.setUrl(url, isLocal);
                 if (position != null && !mode.equals("PlayerMode.LOW_LATENCY")) {


### PR DESCRIPTION
I was trying to use this plugin with [audio_service plugin](https://github.com/ryanheise/audio_service) and turns out that it tries to obtain `Activity` object which is unavailable (returns `null`) in background enviroment. Replaced it with `Context`. This allowed registration of plugin inside Android Service to support background playback.

After this change plugin is ready to be used with audio_service plugin which provides support for background playback (it runs Dart code and audio player plugin both in Android service), notification with controls and AudioFocus handling with Dart callbacks. So potentially it can also (partly) resolve following issues: #288, #202, #264.