### PR TITLE
Fix issue #292: Android race condition loading LOW_LATENCY sounds and loading of duplicate sounds

### DIFF
--- a/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
@@ -16,6 +16,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Collections;
 
@@ -28,18 +30,35 @@ public class WrappedSoundPool extends Player {
         soundPool.setOnLoadCompleteListener(new SoundPool.OnLoadCompleteListener() {
             public void onLoadComplete(SoundPool soundPool, int sampleId, int status) {
                 Log.d("WSP", "Loaded " + sampleId);
-                WrappedSoundPool player = soundIdToPlayer.get(sampleId);
-                if (player != null) {
-                    player.loading = false;
-                    if (player.playing) {
-                        player.start();
+                WrappedSoundPool loadingPlayer = soundIdToPlayer.get(sampleId);
+                if (loadingPlayer != null) {
+                    soundIdToPlayer.remove(loadingPlayer.soundId);
+                    // Now mark all players using this sound as not loading and start them if necessary
+                    synchronized (urlToPlayers) {
+                        List<WrappedSoundPool> urlPlayers = urlToPlayers.get(loadingPlayer.url);
+                        for (WrappedSoundPool player : urlPlayers) {
+                            Log.d("WSP", "Marking " + player + " as loaded");
+                            player.loading = false;
+                            if (player.playing) {
+                                Log.d("WSP", "Delayed start of " + player);
+                                player.start();
+                            }
+                        }
                     }
                 }
             }
         });
     }
 
+    /** For the onLoadComplete listener, track which sound id is associated with which player. An entry only exists until
+     * it has been loaded.
+     */
     private static Map<Integer, WrappedSoundPool> soundIdToPlayer = Collections.synchronizedMap(new HashMap<Integer, WrappedSoundPool>());
+    /** This is to keep track of the players which share the same sound id, referenced by url. When a player release()s, it
+     * is removed from the associated player list. The last player to be removed actually unloads() the sound id and then
+     * the url is removed from this map.
+     */
+    private static Map<String, List<WrappedSoundPool>> urlToPlayers = Collections.synchronizedMap(new HashMap<String, List<WrappedSoundPool>>());
 
 
     private final AudioplayersPlugin ref;
@@ -92,10 +111,22 @@ public class WrappedSoundPool extends Player {
     @Override
     void release() {
         this.stop();
-        if (this.soundId != null) {
-            soundPool.unload(this.soundId);
-            soundIdToPlayer.remove(this.soundId);
-            this.soundId = null;
+        if (this.soundId != null && this.url != null) {
+            synchronized (this.urlToPlayers) {
+                List<WrappedSoundPool> playersForSoundId = this.urlToPlayers.get(this.url);
+                if (playersForSoundId != null) {
+                    if (playersForSoundId.size() == 1 && playersForSoundId.get(0) == this) {
+                        this.urlToPlayers.remove(this.url);
+                        soundPool.unload(this.soundId);
+                        soundIdToPlayer.remove(this.soundId);
+                        this.soundId = null;
+                        Log.d("WSP", "Unloaded soundId " + this.soundId);
+                    } else {
+                        // This is not the last player using the soundId, just remove it from the list.
+                        playersForSoundId.remove(this);
+                    }
+                }
+            }
         }
     }
 
@@ -118,18 +149,30 @@ public class WrappedSoundPool extends Player {
             release();
         }
 
-        this.url = url;
-        this.loading = true;
-
-        // TODO Not sure that start a thread for each load is the sane way to go.
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                final WrappedSoundPool self = WrappedSoundPool.this;
-                self.soundId = soundPool.load(getAudioPath(url, isLocal), 1);
-                soundIdToPlayer.put(self.soundId, self);
+        synchronized (urlToPlayers) {
+            this.url = url;
+            List<WrappedSoundPool> urlPlayers = urlToPlayers.get(url);
+            if (urlPlayers != null) {
+                // Sound has already been loaded - reuse the soundId.
+                WrappedSoundPool originalPlayer = urlPlayers.get(0);
+                this.soundId = originalPlayer.soundId;
+                this.loading = originalPlayer.loading;
+                urlPlayers.add(this);
+                Log.d("WSP", "Reusing soundId" + this.soundId + " for " + url + " is loading=" + this.loading + " " + this);
+                return;
             }
-        }).start();
+
+            // First one for this URL - load it.
+            this.loading = true;
+
+            long start = System.currentTimeMillis();
+            this.soundId = soundPool.load(getAudioPath(url, isLocal), 1);
+            Log.d("WSP", "time to call load() for " + url + ": " + (System.currentTimeMillis() - start) + " player=" + this);
+            soundIdToPlayer.put(this.soundId, this);
+            urlPlayers = new ArrayList<>();
+            urlPlayers.add(this);
+            urlToPlayers.put(url, urlPlayers);
+        }
     }
 
     @Override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,25 +29,6 @@ class _ExampleAppState extends State<ExampleApp> {
   AudioCache audioCache = AudioCache();
   AudioPlayer advancedPlayer = AudioPlayer();
   String localFilePath;
-  AudioPlayer audioPlayer1, audioPlayer2;
-
-  @override
-  initState() {
-    super.initState();
-    _loadAudio();
-  }
-
-  Future _loadAudio() async {
-    var audios = await audioCache.loadAll(['audio.mp3', 'audio2.mp3']);
-    audioPlayer1 = new AudioPlayer(mode: PlayerMode.LOW_LATENCY);
-    audioPlayer2 = new AudioPlayer(mode: PlayerMode.LOW_LATENCY);
-    await audioPlayer1
-        .setUrl(audios[0].path, isLocal: true)
-        .then((_) => print('done1'));
-    await audioPlayer2
-        .setUrl(audios[1].path, isLocal: true)
-        .then((_) => print('done2'));
-  }
 
   Future _loadFile() async {
     final bytes = await readBytes(kUrl1);
@@ -109,17 +90,16 @@ class _ExampleAppState extends State<ExampleApp> {
       Text('Play Local Asset \'audio2.mp3\':'),
       _btn(txt: 'Play', onPressed: () => audioCache.play('audio2.mp3')),
       Text('Play Local Asset In Low Latency \'audio.mp3\':'),
-//      _btn(
-//          txt: 'Play',
-//          onPressed: () =>
-//              audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY)),
+      _btn(
+          txt: 'Play',
+          onPressed: () =>
+              audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY)),
+      Text('Play Local Asset Concurrently In Low Latency \'audio.mp3\':'),
       _btn(
           txt: 'Play',
           onPressed: () async {
-            await audioPlayer1.resume();
-            sleep(Duration(milliseconds: 100));
-            await audioPlayer1.resume();
-            await audioPlayer2.resume();
+            await audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY);
+            await audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY);
           }),
       Text('Play Local Asset In Low Latency \'audio2.mp3\':'),
       _btn(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,25 @@ class _ExampleAppState extends State<ExampleApp> {
   AudioCache audioCache = AudioCache();
   AudioPlayer advancedPlayer = AudioPlayer();
   String localFilePath;
+  AudioPlayer audioPlayer1, audioPlayer2;
+
+  @override
+  initState() {
+    super.initState();
+    _loadAudio();
+  }
+
+  Future _loadAudio() async {
+    var audios = await audioCache.loadAll(['audio.mp3', 'audio2.mp3']);
+    audioPlayer1 = new AudioPlayer(mode: PlayerMode.LOW_LATENCY);
+    audioPlayer2 = new AudioPlayer(mode: PlayerMode.LOW_LATENCY);
+    await audioPlayer1
+        .setUrl(audios[0].path, isLocal: true)
+        .then((_) => print('done1'));
+    await audioPlayer2
+        .setUrl(audios[1].path, isLocal: true)
+        .then((_) => print('done2'));
+  }
 
   Future _loadFile() async {
     final bytes = await readBytes(kUrl1);
@@ -90,10 +109,18 @@ class _ExampleAppState extends State<ExampleApp> {
       Text('Play Local Asset \'audio2.mp3\':'),
       _btn(txt: 'Play', onPressed: () => audioCache.play('audio2.mp3')),
       Text('Play Local Asset In Low Latency \'audio.mp3\':'),
+//      _btn(
+//          txt: 'Play',
+//          onPressed: () =>
+//              audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY)),
       _btn(
           txt: 'Play',
-          onPressed: () =>
-              audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY)),
+          onPressed: () async {
+            await audioPlayer1.resume();
+            sleep(Duration(milliseconds: 100));
+            await audioPlayer1.resume();
+            await audioPlayer2.resume();
+          }),
       Text('Play Local Asset In Low Latency \'audio2.mp3\':'),
       _btn(
           txt: 'Play',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -75,9 +75,7 @@ class _ExampleAppState extends State<ExampleApp> {
       Text('File: $kUrl1'),
       _btn(txt: 'Download File to your Device', onPressed: () => _loadFile()),
       Text('Current local file path: $localFilePath'),
-      localFilePath == null
-          ? Container()
-          : PlayerWidget(url: localFilePath, isLocal: true),
+      localFilePath == null ? Container() : PlayerWidget(url: localFilePath, isLocal: true),
     ]);
   }
 
@@ -90,22 +88,16 @@ class _ExampleAppState extends State<ExampleApp> {
       Text('Play Local Asset \'audio2.mp3\':'),
       _btn(txt: 'Play', onPressed: () => audioCache.play('audio2.mp3')),
       Text('Play Local Asset In Low Latency \'audio.mp3\':'),
-      _btn(
-          txt: 'Play',
-          onPressed: () =>
-              audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY)),
+      _btn(txt: 'Play', onPressed: () => audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY)),
       Text('Play Local Asset Concurrently In Low Latency \'audio.mp3\':'),
       _btn(
           txt: 'Play',
           onPressed: () async {
             await audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY);
-            await audioCache.play('audio.mp3', mode: PlayerMode.LOW_LATENCY);
+            await audioCache.play('audio2.mp3', mode: PlayerMode.LOW_LATENCY);
           }),
       Text('Play Local Asset In Low Latency \'audio2.mp3\':'),
-      _btn(
-          txt: 'Play',
-          onPressed: () =>
-              audioCache.play('audio2.mp3', mode: PlayerMode.LOW_LATENCY)),
+      _btn(txt: 'Play', onPressed: () => audioCache.play('audio2.mp3', mode: PlayerMode.LOW_LATENCY)),
       getLocalFileDuration(),
     ]);
   }
@@ -116,8 +108,7 @@ class _ExampleAppState extends State<ExampleApp> {
       audiofile.path,
       isLocal: true,
     );
-    int duration = await Future.delayed(
-        Duration(seconds: 2), () => advancedPlayer.getDuration());
+    int duration = await Future.delayed(Duration(seconds: 2), () => advancedPlayer.getDuration());
     return duration;
   }
 
@@ -133,8 +124,7 @@ class _ExampleAppState extends State<ExampleApp> {
             return Text('Awaiting result...');
           case ConnectionState.done:
             if (snapshot.hasError) return Text('Error: ${snapshot.error}');
-            return Text(
-                'audio2.mp3 duration is: ${Duration(milliseconds: snapshot.data)}');
+            return Text('audio2.mp3 duration is: ${Duration(milliseconds: snapshot.data)}');
         }
         return null; // unreachable
       },
@@ -144,10 +134,7 @@ class _ExampleAppState extends State<ExampleApp> {
   Widget notification() {
     return _tab(children: [
       Text('Play notification sound: \'messenger.mp3\':'),
-      _btn(
-          txt: 'Play',
-          onPressed: () =>
-              audioCache.play('messenger.mp3', isNotification: true)),
+      _btn(txt: 'Play', onPressed: () => audioCache.play('messenger.mp3', isNotification: true)),
     ]);
   }
 
@@ -155,9 +142,7 @@ class _ExampleAppState extends State<ExampleApp> {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        StreamProvider<Duration>.value(
-            initialData: Duration(),
-            value: advancedPlayer.onAudioPositionChanged),
+        StreamProvider<Duration>.value(initialData: Duration(), value: advancedPlayer.onAudioPositionChanged),
       ],
       child: DefaultTabController(
         length: 5,
@@ -205,8 +190,7 @@ class _AdvancedState extends State<Advanced> {
 
   @override
   void initState() {
-    widget.advancedPlayer.seekCompleteHandler =
-        () => setState(() => seekDone = true);
+    widget.advancedPlayer.seekCompleteHandler = () => setState(() => seekDone = true);
     super.initState();
   }
 
@@ -218,61 +202,35 @@ class _AdvancedState extends State<Advanced> {
         Column(children: [
           Text('Source Url'),
           Row(children: [
-            _btn(
-                txt: 'Audio 1',
-                onPressed: () => widget.advancedPlayer.setUrl(kUrl1)),
-            _btn(
-                txt: 'Audio 2',
-                onPressed: () => widget.advancedPlayer.setUrl(kUrl2)),
-            _btn(
-                txt: 'Stream',
-                onPressed: () => widget.advancedPlayer.setUrl(kUrl3)),
+            _btn(txt: 'Audio 1', onPressed: () => widget.advancedPlayer.setUrl(kUrl1)),
+            _btn(txt: 'Audio 2', onPressed: () => widget.advancedPlayer.setUrl(kUrl2)),
+            _btn(txt: 'Stream', onPressed: () => widget.advancedPlayer.setUrl(kUrl3)),
           ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
         ]),
         Column(children: [
           Text('Release Mode'),
           Row(children: [
-            _btn(
-                txt: 'STOP',
-                onPressed: () =>
-                    widget.advancedPlayer.setReleaseMode(ReleaseMode.STOP)),
-            _btn(
-                txt: 'LOOP',
-                onPressed: () =>
-                    widget.advancedPlayer.setReleaseMode(ReleaseMode.LOOP)),
-            _btn(
-                txt: 'RELEASE',
-                onPressed: () =>
-                    widget.advancedPlayer.setReleaseMode(ReleaseMode.RELEASE)),
+            _btn(txt: 'STOP', onPressed: () => widget.advancedPlayer.setReleaseMode(ReleaseMode.STOP)),
+            _btn(txt: 'LOOP', onPressed: () => widget.advancedPlayer.setReleaseMode(ReleaseMode.LOOP)),
+            _btn(txt: 'RELEASE', onPressed: () => widget.advancedPlayer.setReleaseMode(ReleaseMode.RELEASE)),
           ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
         ]),
         new Column(children: [
           Text('Volume'),
           Row(children: [
-            _btn(
-                txt: '0.0',
-                onPressed: () => widget.advancedPlayer.setVolume(0.0)),
-            _btn(
-                txt: '0.5',
-                onPressed: () => widget.advancedPlayer.setVolume(0.5)),
-            _btn(
-                txt: '1.0',
-                onPressed: () => widget.advancedPlayer.setVolume(1.0)),
-            _btn(
-                txt: '2.0',
-                onPressed: () => widget.advancedPlayer.setVolume(2.0)),
+            _btn(txt: '0.0', onPressed: () => widget.advancedPlayer.setVolume(0.0)),
+            _btn(txt: '0.5', onPressed: () => widget.advancedPlayer.setVolume(0.5)),
+            _btn(txt: '1.0', onPressed: () => widget.advancedPlayer.setVolume(1.0)),
+            _btn(txt: '2.0', onPressed: () => widget.advancedPlayer.setVolume(2.0)),
           ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
         ]),
         new Column(children: [
           Text('Control'),
           Row(children: [
-            _btn(
-                txt: 'resume', onPressed: () => widget.advancedPlayer.resume()),
+            _btn(txt: 'resume', onPressed: () => widget.advancedPlayer.resume()),
             _btn(txt: 'pause', onPressed: () => widget.advancedPlayer.pause()),
             _btn(txt: 'stop', onPressed: () => widget.advancedPlayer.stop()),
-            _btn(
-                txt: 'release',
-                onPressed: () => widget.advancedPlayer.release()),
+            _btn(txt: 'release', onPressed: () => widget.advancedPlayer.release()),
           ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
         ]),
         new Column(
@@ -282,29 +240,25 @@ class _AdvancedState extends State<Advanced> {
               _btn(
                   txt: '100ms',
                   onPressed: () {
-                    widget.advancedPlayer.seek(Duration(
-                        milliseconds: audioPosition.inMilliseconds + 100));
+                    widget.advancedPlayer.seek(Duration(milliseconds: audioPosition.inMilliseconds + 100));
                     setState(() => seekDone = false);
                   }),
               _btn(
                   txt: '500ms',
                   onPressed: () {
-                    widget.advancedPlayer.seek(Duration(
-                        milliseconds: audioPosition.inMilliseconds + 500));
+                    widget.advancedPlayer.seek(Duration(milliseconds: audioPosition.inMilliseconds + 500));
                     setState(() => seekDone = false);
                   }),
               _btn(
                   txt: '1s',
                   onPressed: () {
-                    widget.advancedPlayer
-                        .seek(Duration(seconds: audioPosition.inSeconds + 1));
+                    widget.advancedPlayer.seek(Duration(seconds: audioPosition.inSeconds + 1));
                     setState(() => seekDone = false);
                   }),
               _btn(
                   txt: '1.5s',
                   onPressed: () {
-                    widget.advancedPlayer.seek(Duration(
-                        milliseconds: audioPosition.inMilliseconds + 1500));
+                    widget.advancedPlayer.seek(Duration(milliseconds: audioPosition.inMilliseconds + 1500));
                     setState(() => seekDone = false);
                   }),
             ], mainAxisAlignment: MainAxisAlignment.spaceEvenly),
@@ -333,9 +287,7 @@ class _tab extends StatelessWidget {
       child: Container(
         padding: EdgeInsets.all(16.0),
         child: Column(
-          children: children
-              .map((w) => Container(child: w, padding: EdgeInsets.all(6.0)))
-              .toList(),
+          children: children.map((w) => Container(child: w, padding: EdgeInsets.all(6.0))).toList(),
         ),
       ),
     );
@@ -350,8 +302,6 @@ class _btn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ButtonTheme(
-        minWidth: 48.0,
-        child: RaisedButton(child: Text(txt), onPressed: onPressed));
+    return ButtonTheme(minWidth: 48.0, child: RaisedButton(child: Text(txt), onPressed: onPressed));
   }
 }

--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -58,8 +58,7 @@ class AudioCache {
   }
 
   Future<File> fetchToMemory(String fileName) async {
-//    final file = File('${(await getTemporaryDirectory()).path}/$fileName'); // This requires extra permissions on a real device.
-    final file = File('${(await getApplicationSupportDirectory()).path}/$fileName');
+    final file = File('${(await getTemporaryDirectory()).path}/$fileName');
     await file.create(recursive: true);
     return await file.writeAsBytes((await _fetchAsset(fileName)).buffer.asUint8List());
   }

--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -58,10 +58,10 @@ class AudioCache {
   }
 
   Future<File> fetchToMemory(String fileName) async {
-    final file = File('${(await getTemporaryDirectory()).path}/$fileName');
+//    final file = File('${(await getTemporaryDirectory()).path}/$fileName'); // This requires extra permissions on a real device.
+    final file = File('${(await getApplicationSupportDirectory()).path}/$fileName');
     await file.create(recursive: true);
-    return await file
-        .writeAsBytes((await _fetchAsset(fileName)).buffer.asUint8List());
+    return await file.writeAsBytes((await _fetchAsset(fileName)).buffer.asUint8List());
   }
 
   /// Loads all the [fileNames] provided to the cache.
@@ -91,10 +91,7 @@ class AudioCache {
   /// It creates a new instance of [AudioPlayer], so it does not affect other audios playing (unless you specify a [fixedPlayer], in which case it always use the same).
   /// The instance is returned, to allow later access (either way), like pausing and resuming.
   Future<AudioPlayer> play(String fileName,
-      {double volume = 1.0,
-      bool isNotification,
-      PlayerMode mode = PlayerMode.MEDIA_PLAYER,
-      bool stayAwake}) async {
+      {double volume = 1.0, bool isNotification, PlayerMode mode = PlayerMode.MEDIA_PLAYER, bool stayAwake}) async {
     File file = await load(fileName);
     AudioPlayer player = _player(mode);
     await player.play(
@@ -111,10 +108,7 @@ class AudioCache {
   ///
   /// The instance of [AudioPlayer] created is returned, so you can use it to stop the playback as desired.
   Future<AudioPlayer> loop(String fileName,
-      {double volume = 1.0,
-      bool isNotification,
-      PlayerMode mode = PlayerMode.MEDIA_PLAYER,
-      bool stayAwake}) async {
+      {double volume = 1.0, bool isNotification, PlayerMode mode = PlayerMode.MEDIA_PLAYER, bool stayAwake}) async {
     File file = await load(fileName);
     AudioPlayer player = _player(mode);
     player.setReleaseMode(ReleaseMode.LOOP);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,14 +21,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   charcode:
     dependency: transitive
     description:
@@ -157,7 +157,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.7"
   mime:
     dependency: transitive
     description:
@@ -199,7 +199,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.4"
   path_provider:
     dependency: "direct main"
     description:
@@ -213,7 +213,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0+1"
   pool:
     dependency: transitive
     description:
@@ -234,7 +234,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   shelf:
     dependency: transitive
     description:
@@ -309,7 +309,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   term_glyph:
     dependency: transitive
     description:


### PR DESCRIPTION
This addresses issue #292 when two or more LOW_LATENCY sounds were loaded concurrently, only the last sound would be playable, the others would be left in a `loading` state. There can only be one `OnLoadCompleteListener` per `SoundPool`. The `SoundPool` variable is static and the `setUrl()` method kept resetting to be the latest instance of `WrappedSoundPool`, so only the latest sound was marked as loaded.

It also address an issue where the playing the same sound repeatedly caused the sound to be loaded again and again. `WrappedSoundPool` now keeps a map of URIs -> sound ids and reuses the sound id when the same URI is played again. `WrappedSoundPool` was confounding the idea of a loaded sound and the playing of a loaded sound. You could not play multiple instances of the same loaded sound without loading it again. This is needed in games, for example, for things like fast concurrent explosions or firings. Each `AudioPlayer` now represents a playing sound even if that sound is the same instance being played by another `AudioPlayer`.