### PR TITLE
add options

### DIFF
--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -408,9 +408,9 @@ float _playbackRate = 1.0;
   // code moved from play() to setUrl() to fix the bug of audio not playing in ios background
   NSError *error = nil;
   AVAudioSessionCategory category = respectSilence ? AVAudioSessionCategoryAmbient : AVAudioSessionCategoryPlayback;
-  BOOL success = [[AVAudioSession sharedInstance]
-                  setCategory: category
-                  error:&error];
+    
+  BOOL success = [[AVAudioSession sharedInstance] setCategory:category withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
+    
   if (!success) {
     NSLog(@"Error setting speaker: %@", error);
   }


### PR DESCRIPTION
The audio playing by the player will stop other app's music playing background just in iOS.
So int this PR, the `option` parameter is added to the `category` in `AVAudioSession` to make sure the audio and the music playing background will work together.