### PR TITLE
345 - fix for startHeadlessService() crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [next]
+ - fixed crash on iOS when `startHeadlessService()` wasn't called on `AudioPlayer` (by @JesseScott)
 
 ## audioplayers 0.13.4
  - fixing missing cleanup on hot restart on Android

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,6 +30,18 @@ class _ExampleAppState extends State<ExampleApp> {
   AudioPlayer advancedPlayer = AudioPlayer();
   String localFilePath;
 
+  @override
+  void initState() {
+    super.initState();
+
+    if (Platform.isIOS) {
+      if (audioCache.fixedPlayer != null) {
+        audioCache.fixedPlayer.startHeadlessService();
+      }
+      advancedPlayer.startHeadlessService();
+    }
+  }
+
   Future _loadFile() async {
     final bytes = await readBytes(kUrl1);
     final dir = await getApplicationDocumentsDirectory();

--- a/example/lib/player_widget.dart
+++ b/example/lib/player_widget.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/foundation.dart';
@@ -126,6 +127,9 @@ class _PlayerWidgetState extends State<PlayerWidget> {
 
   void _initAudioPlayer() {
     _audioPlayer = AudioPlayer(mode: mode);
+    if (Platform.isIOS) {
+      _audioPlayer.startHeadlessService();
+    }
 
     _durationSubscription = _audioPlayer.onDurationChanged.listen((duration) {
       setState(() => _duration = duration);

--- a/example/lib/player_widget.dart
+++ b/example/lib/player_widget.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/foundation.dart';
@@ -127,16 +126,16 @@ class _PlayerWidgetState extends State<PlayerWidget> {
 
   void _initAudioPlayer() {
     _audioPlayer = AudioPlayer(mode: mode);
-    if (Platform.isIOS) {
-      _audioPlayer.startHeadlessService();
-    }
 
     _durationSubscription = _audioPlayer.onDurationChanged.listen((duration) {
       setState(() => _duration = duration);
 
       // TODO implemented for iOS, waiting for android impl
       if (Theme.of(context).platform == TargetPlatform.iOS) {
-        // set atleast title to see the notification bar on ios.
+        // (Optional) listen for notification updates in the background
+        _audioPlayer.startHeadlessService();
+
+        // set at least title to see the notification bar on ios.
         _audioPlayer.setNotification(
             title: 'App Name',
             artist: 'Artist or blank',

--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -102,12 +102,13 @@ float _playbackRate = 1.0;
   // Here we actually launch the background isolate to start executing our
   // callback dispatcher, `_backgroundCallbackDispatcher`, in Dart.
   headlessServiceInitialized = [_headlessEngine runWithEntrypoint:entrypoint libraryURI:uri];
-
-  // The headless runner needs to be initialized before we can register it as a
-  // MethodCallDelegate or else we get an illegal memory access. If we don't
-  // want to make calls from `_backgroundCallDispatcher` back to native code,
-  // we don't need to add a MethodCallDelegate for this channel.
-  [_registrar addMethodCallDelegate:self channel:_callbackChannel];
+  if (headlessServiceInitialized) {
+      // The headless runner needs to be initialized before we can register it as a
+      // MethodCallDelegate or else we get an illegal memory access. If we don't
+      // want to make calls from `_backgroundCallDispatcher` back to native code,
+      // we don't need to add a MethodCallDelegate for this channel.
+      [_registrar addMethodCallDelegate:self channel:_callbackChannel];
+  }
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {

--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -33,6 +33,7 @@ FlutterEngine *_headlessEngine;
 FlutterMethodChannel *_callbackChannel;
 NSObject<FlutterPluginRegistrar> *_registrar;
 int64_t _updateHandleMonitorKey;
+bool headlessServiceInitialized = false;
 
 NSString *_currentPlayerId; // to be used for notifications command center
 MPNowPlayingInfoCenter *_infoCenter;
@@ -100,7 +101,7 @@ float _playbackRate = 1.0;
 
   // Here we actually launch the background isolate to start executing our
   // callback dispatcher, `_backgroundCallbackDispatcher`, in Dart.
-  [_headlessEngine runWithEntrypoint:entrypoint libraryURI:uri];
+  headlessServiceInitialized = [_headlessEngine runWithEntrypoint:entrypoint libraryURI:uri];
 
   // The headless runner needs to be initialized before we can register it as a
   // MethodCallDelegate or else we get an illegal memory access. If we don't
@@ -628,7 +629,9 @@ float _playbackRate = 1.0;
   }
 
   [ _channel_audioplayer invokeMethod:@"audio.onComplete" arguments:@{@"playerId": playerId}];
-  [_callbackChannel invokeMethod:@"audio.onNotificationBackgroundPlayerStateChanged" arguments:@{@"playerId": playerId, @"updateHandleMonitorKey": @(_updateHandleMonitorKey), @"value": @"completed"}];
+  if (headlessServiceInitialized) {
+      [_callbackChannel invokeMethod:@"audio.onNotificationBackgroundPlayerStateChanged" arguments:@{@"playerId": playerId, @"updateHandleMonitorKey": @(_updateHandleMonitorKey), @"value": @"completed"}];
+  }
 }
 
 -(void)observeValueForKeyPath:(NSString *)keyPath

--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -62,7 +62,7 @@ float _playbackRate = 1.0;
       players = [[NSMutableDictionary alloc] init];
       [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(needStop) name:AudioplayersPluginStop object:nil];
 
-      // this methos is used to listen to audio playpause event
+      // this method is used to listen to audio playpause event
       // from the notification area in the background.
       _headlessEngine = [[FlutterEngine alloc] initWithName:@"AudioPlayerIsolate"
                                                     project:nil];
@@ -80,7 +80,7 @@ float _playbackRate = 1.0;
     
 - (void)needStop {
     _isDealloc = true;
-    [self destory];
+    [self destroy];
 }
 
 // Initializes and starts the background isolate which will process audio
@@ -663,7 +663,7 @@ float _playbackRate = 1.0;
   }
 }
 
-- (void)destory {
+- (void)destroy {
     for (id value in timeobservers)
     [value[@"player"] removeTimeObserver:value[@"observer"]];
     timeobservers = nil;
@@ -678,7 +678,7 @@ float _playbackRate = 1.0;
 }
     
 - (void)dealloc {
-    [self destory];
+    [self destroy];
 }
 
 

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -298,6 +298,9 @@ class AudioPlayer {
   /// this should be called after initiating AudioPlayer only if you want to
   /// listen for notification changes in the background
   void startHeadlessService() {
+    if (this == null || playerId.isEmpty) {
+      return;
+    }
     // Start the headless audio service. The parameter here is a handle to
     // a callback managed by the Flutter engine, which allows for us to pass
     // references to our callbacks between isolates.


### PR DESCRIPTION
#### :ticket: Issue

- https://github.com/luanpotter/audioplayers/issues/345

#### :grey_question:  What does this PR do?

- Fixes #345 by wrapping call to `"audio.onNotificationBackgroundPlayerStateChanged"` in a conditional that is only set by the proper method being called that would ensure that the FlutterEngine has properly registered the handler

#### :globe_with_meridians:  Where should the reviewer start?

- `ios/Classes/AudioplayersPlugin.m`

#### :microscope:  How should this be manually tested?

- Run the example app
  -- comment out the call to `_audioPlayer.startHeadlessService();` in `player_widget.dart`

#### :notebook:  Any background context you want to provide?

- 😅 been a long time since i had to code **Objective-C** 

#### :camera:  Screenshots / Screencasts

 - N/A

#### :sparkles:  What gif best describes this PR or how it makes you feel?

- https://media.giphy.com/media/39vl0ey26JznsznUHm/giphy.gif

#### :white_check_mark: Test Results

- Tests pass, but no new ones added