### PR TITLE
Update AudioplayersPlugin.m

### DIFF
--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -412,10 +412,18 @@ float _playbackRate = 1.0;
 
   // code moved from play() to setUrl() to fix the bug of audio not playing in ios background
   NSError *error = nil;
+  BOOL success = false;
+
   AVAudioSessionCategory category = respectSilence ? AVAudioSessionCategoryAmbient : AVAudioSessionCategoryPlayback;
-    
-  BOOL success = [[AVAudioSession sharedInstance] setCategory:category withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
-    
+  // When using AVAudioSessionCategoryPlayback, by default, this implies that your app’s audio is nonmixable—activating your session 
+  // will interrupt any other audio sessions which are also nonmixable. AVAudioSessionCategoryPlayback should not be used with
+  // AVAudioSessionCategoryOptionMixWithOthers option. If so, it prevents infoCenter from working correctly.
+  if (respectSilence) {
+    success = [[AVAudioSession sharedInstance] setCategory:category withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
+  } else {
+    success = [[AVAudioSession sharedInstance] setCategory:category error:&error];
+  }
+
   if (!success) {
     NSLog(@"Error setting speaker: %@", error);
   }


### PR DESCRIPTION
This pull request is response to #325 

Use AVAudioSessionCategoryOptionMixWithOthers if silence is not desired. Address issue with infoCenter not working with AVAudioSessionCategoryOptionMixWithOthers. It makes sense not to use AVAudioSessionCategoryOptionMixWithOthers option when silence is not desired. 