### PR TITLE
make AVAudioSessionCategoryOptionMixWithOthers optional

### DIFF
--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -149,11 +149,12 @@ float _playbackRate = 1.0;
                     float volume = (float)[call.arguments[@"volume"] doubleValue] ;
                     int milliseconds = call.arguments[@"position"] == [NSNull null] ? 0.0 : [call.arguments[@"position"] intValue] ;
                     bool respectSilence = [call.arguments[@"respectSilence"]boolValue] ;
+                    bool mixWithOthers = [call.arguments[@"mixWithOthers"]boolValue] ;
                     CMTime time = CMTimeMakeWithSeconds(milliseconds / 1000,NSEC_PER_SEC);
                     NSLog(@"isLocal: %d %@", isLocal, call.arguments[@"isLocal"] );
                     NSLog(@"volume: %f %@", volume, call.arguments[@"volume"] );
                     NSLog(@"position: %d %@", milliseconds, call.arguments[@"positions"] );
-                    [self play:playerId url:url isLocal:isLocal volume:volume time:time isNotification:respectSilence];
+                    [self play:playerId url:url isLocal:isLocal volume:volume time:time mixWithOthers:mixWithOthers isNotification:respectSilence];
                   },
                 @"pause":
                   ^{
@@ -192,10 +193,12 @@ float _playbackRate = 1.0;
                     NSString *url = call.arguments[@"url"];
                     int isLocal = [call.arguments[@"isLocal"]intValue];
                     bool respectSilence = [call.arguments[@"respectSilence"]boolValue] ;
+                    bool mixWithOthers = [call.arguments[@"mixWithOthers"]boolValue] ;
                     [ self setUrl:url
                           isLocal:isLocal
                           isNotification:respectSilence
                           playerId:playerId
+                          mixWithOthers:mixWithOthers
                           onReady:^(NSString * playerId) {
                             result(@(1));
                           }
@@ -491,12 +494,14 @@ float _playbackRate = 1.0;
      isLocal: (int) isLocal
       volume: (float) volume
         time: (CMTime) time
+       mixWithOthers: (bool) mixWithOthers
       isNotification: (bool) respectSilence
 {
   [ self setUrl:url 
          isLocal:isLocal 
          isNotification:respectSilence
          playerId:playerId 
+         mixWithOthers:mixWithOthers 
          onReady:^(NSString * playerId) {
            NSMutableDictionary * playerInfo = players[playerId];
            AVPlayer *player = playerInfo[@"player"];

--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -400,6 +400,7 @@ float _playbackRate = 1.0;
        isLocal: (bool) isLocal
        isNotification: (bool) respectSilence
        playerId: (NSString*) playerId
+       mixWithOthers: (bool) mixWithOthers
        onReady:(VoidCallback)onReady
 {
   NSMutableDictionary * playerInfo = players[playerId];
@@ -414,7 +415,12 @@ float _playbackRate = 1.0;
   NSError *error = nil;
   AVAudioSessionCategory category = respectSilence ? AVAudioSessionCategoryAmbient : AVAudioSessionCategoryPlayback;
     
-  BOOL success = [[AVAudioSession sharedInstance] setCategory:category withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
+  BOOL success;
+  if(mixWithOthers) {
+    success = [[AVAudioSession sharedInstance] setCategory:category withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
+  } else {
+    success = [[AVAudioSession sharedInstance] setCategory:category error:&error];
+  }
     
   if (!success) {
     NSLog(@"Error setting speaker: %@", error);

--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -419,6 +419,7 @@ float _playbackRate = 1.0;
   AVAudioSessionCategory category = respectSilence ? AVAudioSessionCategoryAmbient : AVAudioSessionCategoryPlayback;
     
   BOOL success;
+  // make AVAudioSessionCategoryOptionMixWithOthers optional
   if(mixWithOthers) {
     success = [[AVAudioSession sharedInstance] setCategory:category withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
   } else {

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -485,6 +485,10 @@ class AudioPlayer {
   ///
   /// The resources will start being fetched or buffered as soon as you call
   /// this method.
+  /// 
+  /// By default mixWithOthers is set to false. If it is set to true, it can 
+  /// play along with other audio from other apps. But then the lock screen notification 
+  /// for the audio will not be displayed.
   Future<int> setUrl(String url,
       {bool isLocal: false, bool respectSilence = false , bool mixWithOthers = false}) {
     return _invokeMethod('setUrl',

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -344,11 +344,13 @@ class AudioPlayer {
     Duration position,
     bool respectSilence = false,
     bool stayAwake = false,
+    bool mixWithOthers = false
   }) async {
     isLocal ??= false;
     volume ??= 1.0;
     respectSilence ??= false;
     stayAwake ??= false;
+    mixWithOthers ??= false;
 
     final int result = await _invokeMethod('play', {
       'url': url,
@@ -357,6 +359,7 @@ class AudioPlayer {
       'position': position?.inMilliseconds,
       'respectSilence': respectSilence,
       'stayAwake': stayAwake,
+      'mixWithOthers': mixWithOthers,
     });
 
     if (result == 1) {
@@ -483,9 +486,9 @@ class AudioPlayer {
   /// The resources will start being fetched or buffered as soon as you call
   /// this method.
   Future<int> setUrl(String url,
-      {bool isLocal: false, bool respectSilence = false}) {
+      {bool isLocal: false, bool respectSilence = false , bool mixWithOthers = false}) {
     return _invokeMethod('setUrl',
-        {'url': url, 'isLocal': isLocal, 'respectSilence': respectSilence});
+        {'url': url, 'isLocal': isLocal, 'respectSilence': respectSilence, 'mixWithOthers': mixWithOthers});
   }
 
   /// Get audio duration after setting url.


### PR DESCRIPTION
In commit b69221179874b831ef813b8ecc0438d8c2aa79ce, AVAudioSessionCategoryOptionMixWithOthers was added to play() on iOS. Because of this the notification area doesn't work as iOS thinks your app audio is not the main audio playing. So I think mixWithOthers should be made optional by passing as parameter to play() and setUrl(). Please let me know if there is any issue.