### PR TITLE
Add documentation about streaming audio from http links

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,23 +81,6 @@ If you pass `setAwake` as true you need to add this permission to your app manif
   }
 ```
 
-**Note:** On Android by default, there is a restriction not allowing traffic from HTTP resources. There is a fix for this and it requires
-adding `android:usesCleartextTraffic="true"` within your AndroidManifest.xml file located in `android/app/src/main/AndroidManifest.xml`.
-
-Here is an example of how it should look like:
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<manifest ...>
-    <uses-permission android:name="android.permission.INTERNET" />
-    <application
-        ...
-        android:usesCleartextTraffic="true"
-        ...>
-        ...
-    </application>
-</manifest>
-```
-
 For a Local File, add the `isLocal` parameter:
 
 ```dart
@@ -271,6 +254,23 @@ By default iOS forbids loading from non-https url. To cancel this restriction yo
     <key>NSAllowsArbitraryLoads</key>
     <true/>
 </dict>
+```
+
+**Note:** On Android by default, there is a restriction not allowing traffic from HTTP resources. There is a fix for this and it requires
+adding `android:usesCleartextTraffic="true"` within your AndroidManifest.xml file located in `android/app/src/main/AndroidManifest.xml`.
+
+Here is an example of how it should look like:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest ...>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application
+        ...
+        android:usesCleartextTraffic="true"
+        ...>
+        ...
+    </application>
+</manifest>
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ If you pass `setAwake` as true you need to add this permission to your app manif
   }
 ```
 
+**Note:** On Android by default, there is a restriction not allowing traffic from HTTP resources. There is a fix for this and it requires
+adding `android:usesCleartextTraffic="true"` within your AndroidManifest.xml file located in `android/app/src/main/AndroidManifest.xml`.
+
+Here is an example of how it should look like:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest ...>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application
+        ...
+        android:usesCleartextTraffic="true"
+        ...>
+        ...
+    </application>
+</manifest>
+```
+
 For a Local File, add the `isLocal` parameter:
 
 ```dart


### PR DESCRIPTION
There has been an issue causing playing remote urls that are HTTP not to work and after some research, I found out that this is specific to Android only and can be fixed by adding `android:usesCleartextTraffic="true"` in the AndroidManifest.xml file. I figured this info should be included in the docs since there are multiple folks who ran into it as well.

This PR should close out these issues: #375, #369, possibly #181, and #383 