### PR TITLE
[iOS] Add `playImmediatelyAtRate` to `resume` and updated `play`

### DIFF
--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -530,9 +530,10 @@ const float _defaultPlaybackRate = 1.0;
            [ player seekToTime:time ];
 
            if (@available(iOS 10.0, *)) {
-             [player playImmediatelyAtRate:_defaultPlaybackRate];
+             float playbackRate = [playerInfo[@"rate"] floatValue];
+             [player playImmediatelyAtRate:playbackRate];
            } else {
-             [ player play];
+             [player play];
            }
 
            [ playerInfo setObject:@true forKey:@"isPlaying" ];
@@ -595,9 +596,12 @@ const float _defaultPlaybackRate = 1.0;
 -(void) resume: (NSString *) playerId {
   NSMutableDictionary * playerInfo = players[playerId];
   AVPlayer *player = playerInfo[@"player"];
-  float playbackRate = [ playerInfo[@"rate"] floatValue];
-  [player play];
-  [ player setRate:playbackRate ];
+  float playbackRate = [playerInfo[@"rate"] floatValue];
+  if (@available(iOS 10.0, *)) {
+    [player playImmediatelyAtRate:playbackRate];
+  } else {
+    [player play];
+  }
   [playerInfo setObject:@true forKey:@"isPlaying"];
 }
 


### PR DESCRIPTION
## Note
- This commit implies iOS users _should_ be able to set playback rate prior to playing. Needs testing to be confirmed. Currently here's the docs recommendation on `setPlaybackRate`: [Sets the playback rate - call this after first calling play() or resume().](https://github.com/luanpotter/audioplayers/blob/master/lib/audioplayers.dart#L452)

## Changes
- Added `playImmediatelyAtRate` to `resume` method with `playbackRate` read from playerInfo's `rate`
- Modified `playImmediatelyAtRate` in `play` method to take `playbackRate` read from playerInfo's `rate` instead of using the constant `_defaultPlaybackRate`