### PR TITLE
Prevent exceptions when null values are passed to notifications center

### DIFF
--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -466,8 +466,8 @@ class AudioPlayer {
       String albumTitle,
       String artist,
       String imageUrl,
-      Duration forwardSkipInterval = const Duration(seconds: 30),
-      Duration backwardSkipInterval = const Duration(seconds: 30),
+      Duration forwardSkipInterval,
+      Duration backwardSkipInterval,
       Duration duration,
       Duration elapsedTime}) {
     return _invokeMethod('setNotification', {
@@ -561,6 +561,7 @@ class AudioPlayer {
         break;
       case 'audio.onSeekComplete':
         player._seekCompleteController.add(value);
+        // ignore: deprecated_member_use_from_same_package
         player.seekCompleteHandler?.call(value);
         break;
       case 'audio.onError':

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:uuid/uuid.dart';
-
-// Required for PluginUtilities.
-import 'dart:ui';
-import 'package:flutter/material.dart';
 
 typedef StreamController CreateStreamController();
 typedef void TimeChangeHandler(Duration duration);
@@ -465,18 +463,18 @@ class AudioPlayer {
   /// Specify atleast title
   Future<dynamic> setNotification(
       {String title,
-      String albumTitle = '',
-      String artist = '',
-      String imageUrl = '',
+      String albumTitle,
+      String artist,
+      String imageUrl,
       Duration forwardSkipInterval = const Duration(seconds: 30),
       Duration backwardSkipInterval = const Duration(seconds: 30),
       Duration duration,
       Duration elapsedTime}) {
     return _invokeMethod('setNotification', {
-      'title': title,
-      'albumTitle': albumTitle,
-      'artist': artist,
-      'imageUrl': imageUrl,
+      'title': title ?? '',
+      'albumTitle': albumTitle ?? '',
+      'artist': artist ?? '',
+      'imageUrl': imageUrl ?? '',
       'forwardSkipInterval': forwardSkipInterval?.inSeconds ?? 30,
       'backwardSkipInterval': backwardSkipInterval?.inSeconds ?? 30,
       'duration': duration?.inSeconds ?? 0,


### PR DESCRIPTION
Initializing parameters does nothing if an app passes the null values.