### PR TITLE
iOS Fix lost/inaccurate milliseconds in `onCurrentPosition`

### DIFF
--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -582,7 +582,8 @@ const float _defaultPlaybackRate = 1.0;
     if (_isDealloc) {
         return;
     }
-    int seconds = CMTimeGetSeconds(time);
+    // Casting to Float64 preserves precision/decimal points
+    Float64 seconds = CMTimeGetSeconds(time);
     int mseconds = seconds*1000;
     
     [_channel_audioplayer invokeMethod:@"audio.onCurrentPosition" arguments:@{@"playerId": playerId, @"value": @(mseconds)}];


### PR DESCRIPTION
## Description
Previously, `onAudioPositionChanged` is returning milliseconds rounded up to seconds. This is because  `CMTimeGetSeconds(time);` is being cast to int instead of `Float64`. The latter retains decimal/precision points.

## Change
Changed:
```Objc
int seconds = CMTimeGetSeconds(time);
```
To:
```Objc
Float64 seconds = CMTimeGetSeconds(time);
```

## Reference
For reference, check [this](https://stackoverflow.com/a/6655128/10830091).

## Issue with temporary fix
See [this](https://github.com/luanpotter/audioplayers/issues/414) issue for a temporary fix until this PR is merged. 