### PR TITLE
[Android] Added feature, switch between  speakers and earpiece

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ If you are not on RELEASE mode, you should call the release method yourself; for
 
 Despite the complex state diagram of Android's MediaPlayer, an AudioPlayer instance should never have an invalid state. Even if it's released, if resume is called, the data will be fetch again.
 
+#### Stream routing
+You can choose between speakers and earpiece. By default using speakers.
+Toggle between speakers and earpiece.
+```
+int result = await player.earpieceOrSpeakersToggle();
+```
+
 ### Streams
 
 The AudioPlayer supports subscribing to events like so:

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Here is an example of how it should look like:
     </application>
 </manifest>
 ```
+## :warning: iOS stream routing not implemented
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Toggle between speakers and earpiece.
 int result = await player.earpieceOrSpeakersToggle();
 ```
 
+ :warning: **iOS stream routing not implemented**
+
 ### Streams
 
 The AudioPlayer supports subscribing to events like so:
@@ -287,7 +289,6 @@ Here is an example of how it should look like:
     </application>
 </manifest>
 ```
-## :warning: iOS stream routing not implemented
 
 ## Credits
 

--- a/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
+++ b/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
@@ -62,15 +62,15 @@ public class AudioplayersPlugin implements MethodCallHandler {
                 final boolean stayAwake = call.argument("stayAwake");
                 player.configAttributes(respectSilence, stayAwake, context.getApplicationContext());
                 player.setVolume(volume);
-                player.setUrl(url, isLocal);
+                player.setUrl(url, isLocal, context.getApplicationContext());
                 if (position != null && !mode.equals("PlayerMode.LOW_LATENCY")) {
                     player.seek(position);
                 }
-                player.play();
+                player.play(context.getApplicationContext());
                 break;
             }
             case "resume": {
-                player.play();
+                player.play(context.getApplicationContext());
                 break;
             }
             case "pause": {
@@ -98,7 +98,7 @@ public class AudioplayersPlugin implements MethodCallHandler {
             case "setUrl": {
                 final String url = call.argument("url");
                 final boolean isLocal = call.argument("isLocal");
-                player.setUrl(url, isLocal);
+                player.setUrl(url, isLocal, context.getApplicationContext());
                 break;
             }
             case "setPlaybackRate": {
@@ -118,6 +118,11 @@ public class AudioplayersPlugin implements MethodCallHandler {
                 final String releaseModeName = call.argument("releaseMode");
                 final ReleaseMode releaseMode = ReleaseMode.valueOf(releaseModeName.substring("ReleaseMode.".length()));
                 player.setReleaseMode(releaseMode);
+                break;
+            }
+            case "earpieceOrSpeakersToggle": {
+                final String playingRoute = call.argument("playingRoute");
+                player.setPlayingRoute(playingRoute, context.getApplicationContext());
                 break;
             }
             default: {

--- a/android/src/main/java/xyz/luan/audioplayers/Player.java
+++ b/android/src/main/java/xyz/luan/audioplayers/Player.java
@@ -9,7 +9,7 @@ abstract class Player {
 
     abstract String getPlayerId();
 
-    abstract void play();
+    abstract void play(Context context);
 
     abstract void stop();
 
@@ -17,7 +17,7 @@ abstract class Player {
 
     abstract void pause();
 
-    abstract void setUrl(String url, boolean isLocal);
+    abstract void setUrl(String url, boolean isLocal, Context context);
 
     abstract void setVolume(double volume);
 
@@ -32,6 +32,8 @@ abstract class Player {
     abstract int getCurrentPosition();
 
     abstract boolean isActuallyPlaying();
+
+    abstract void setPlayingRoute(String playingRoute, Context context);
 
     /**
      * Seek operations cannot be called until after the player is ready.

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
@@ -70,7 +70,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
 
     @Override
     void setPlayingRoute(String playingRoute, Context context) {
-        if ( ! objectEquals(this.playingRoute, playingRoute) ) {
+        if (!objectEquals(this.playingRoute, playingRoute)) {
             boolean wasPlaying = this.playing;
             if (wasPlaying) {
                 this.pause();
@@ -86,7 +86,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
             this.released = false;
             this.player = createPlayer(context);
             this.setSource(url);
-            try{
+            try {
                 this.player.prepare();
             } catch (IOException ex) {
                 throw new RuntimeException("Unable to access resource", ex);
@@ -293,7 +293,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
     @SuppressWarnings("deprecation")
     private void setAttributes(MediaPlayer player, Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            if ( objectEquals(this.playingRoute, "speakers") ) {
+            if (objectEquals(this.playingRoute, "speakers")) {
                 player.setAudioAttributes(new AudioAttributes.Builder()
                     .setUsage(respectSilence ? AudioAttributes.USAGE_NOTIFICATION_RINGTONE : AudioAttributes.USAGE_MEDIA)
                     .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
@@ -315,7 +315,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
 
         } else {
             // This method is deprecated but must be used on older devices
-            if ( objectEquals(this.playingRoute, "speakers") ) {
+            if (objectEquals(this.playingRoute, "speakers")) {
                 player.setAudioStreamType(respectSilence ? AudioManager.STREAM_RING : AudioManager.STREAM_MUSIC);
             } else {
                 player.setAudioStreamType(AudioManager.STREAM_VOICE_CALL);

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
@@ -315,7 +315,11 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
 
         } else {
             // This method is deprecated but must be used on older devices
-            player.setAudioStreamType(respectSilence ? AudioManager.STREAM_RING : AudioManager.STREAM_MUSIC);
+            if ( objectEquals(this.playingRoute, "speakers") ) {
+                player.setAudioStreamType(respectSilence ? AudioManager.STREAM_RING : AudioManager.STREAM_MUSIC);
+            } else {
+                player.setAudioStreamType(AudioManager.STREAM_VOICE_CALL);
+            }
         }
     }
 

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
@@ -19,6 +19,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
     private boolean respectSilence;
     private boolean stayAwake;
     private ReleaseMode releaseMode = ReleaseMode.RELEASE;
+    private String playingRoute = "speakers";
 
     private boolean released = true;
     private boolean prepared = false;
@@ -39,11 +40,11 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
      */
 
     @Override
-    void setUrl(String url, boolean isLocal) {
+    void setUrl(String url, boolean isLocal, Context context) {
         if (!objectEquals(this.url, url)) {
             this.url = url;
             if (this.released) {
-                this.player = createPlayer();
+                this.player = createPlayer(context);
                 this.released = false;
             } else if (this.prepared) {
                 this.player.reset();
@@ -68,6 +69,38 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
     }
 
     @Override
+    void setPlayingRoute(String playingRoute, Context context) {
+        if ( ! objectEquals(this.playingRoute, playingRoute) ) {
+            boolean wasPlaying = this.playing;
+            if (wasPlaying) {
+                this.pause();
+            }
+
+            this.playingRoute = playingRoute;
+
+            int position = 0;
+            if (player != null) {
+                position = player.getCurrentPosition();
+            }
+
+            this.released = false;
+            this.player = createPlayer(context);
+            this.setSource(url);
+            try{
+                this.player.prepare();
+            } catch (IOException ex) {
+                throw new RuntimeException("Unable to access resource", ex);
+            }
+
+            this.seek(position);
+            if (wasPlaying) {
+                this.playing = true;
+                this.player.start();
+            }
+        }
+    }
+
+    @Override
     int setRate(double rate) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             throw new UnsupportedOperationException("The method 'setRate' is available only on Android SDK version " + Build.VERSION_CODES.M + " or higher!");
@@ -85,7 +118,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
         if (this.respectSilence != respectSilence) {
             this.respectSilence = respectSilence;
             if (!this.released) {
-                setAttributes(player);
+                setAttributes(player, context);
             }
         }
         if (this.stayAwake != stayAwake) {
@@ -135,12 +168,12 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
      */
 
     @Override
-    void play() {
+    void play(Context context) {
         if (!this.playing) {
             this.playing = true;
             if (this.released) {
                 this.released = false;
-                this.player = createPlayer();
+                this.player = createPlayer(context);
                 this.setSource(url);
                 this.player.prepareAsync();
             } else if (this.prepared) {
@@ -238,12 +271,12 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
      * Internal logic. Private methods
      */
 
-    private MediaPlayer createPlayer() {
+    private MediaPlayer createPlayer(Context context) {
         MediaPlayer player = new MediaPlayer();
         player.setOnPreparedListener(this);
         player.setOnCompletionListener(this);
         player.setOnSeekCompleteListener(this);
-        setAttributes(player);
+        setAttributes(player, context);
         player.setVolume((float) volume, (float) volume);
         player.setLooping(this.releaseMode == ReleaseMode.LOOP);
         return player;
@@ -258,13 +291,28 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
     }
 
     @SuppressWarnings("deprecation")
-    private void setAttributes(MediaPlayer player) {
+    private void setAttributes(MediaPlayer player, Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            player.setAudioAttributes(new AudioAttributes.Builder()
+            if ( objectEquals(this.playingRoute, "speakers") ) {
+                player.setAudioAttributes(new AudioAttributes.Builder()
                     .setUsage(respectSilence ? AudioAttributes.USAGE_NOTIFICATION_RINGTONE : AudioAttributes.USAGE_MEDIA)
                     .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
                     .build()
-            );
+                );
+            } else {
+                // Works with bluetooth headphones
+                // automatically switch to earpiece when disconnect bluetooth headphones
+                player.setAudioAttributes(new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                    .build()
+                );
+                if ( context != null ) {
+                    AudioManager mAudioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+                    mAudioManager.setSpeakerphoneOn(false);
+                }
+            }
+
         } else {
             // This method is deprecated but must be used on older devices
             player.setAudioStreamType(respectSilence ? AudioManager.STREAM_RING : AudioManager.STREAM_MUSIC);

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
@@ -83,6 +83,8 @@ public class WrappedSoundPool extends Player {
 
     private boolean loading = false;
 
+    private String playingRoute = "speakers";
+
     WrappedSoundPool(AudioplayersPlugin ref, String playerId) {
         this.ref = ref;
         this.playerId = playerId;
@@ -94,7 +96,7 @@ public class WrappedSoundPool extends Player {
     }
 
     @Override
-    void play() {
+    void play(Context context) {
         if (!this.loading) {
             start();
         }
@@ -142,7 +144,7 @@ public class WrappedSoundPool extends Player {
     }
 
     @Override
-    void setUrl(final String url, final boolean isLocal) {
+    void setUrl(final String url, final boolean isLocal, Context context) {
         if (this.url != null && this.url.equals(url)) {
             return;
         }
@@ -223,14 +225,24 @@ public class WrappedSoundPool extends Player {
     }
 
     @Override
+    void setPlayingRoute(String playingRoute, Context context) {
+        throw unsupportedOperation("setPlayingRoute");
+    }
+
+    @Override
     void seek(int position) {
         throw unsupportedOperation("seek");
     }
 
     private static SoundPool createSoundPool() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            AudioAttributes attrs = new AudioAttributes.Builder().setLegacyStreamType(AudioManager.USE_DEFAULT_STREAM_TYPE)
+            AudioAttributes attrs = new AudioAttributes
+                    .Builder()
+                    .setLegacyStreamType(AudioManager.USE_DEFAULT_STREAM_TYPE)
+//                    .setLegacyStreamType(AudioManager.STREAM_VOICE_CALL)
                     .setUsage(AudioAttributes.USAGE_GAME)
+//                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+//                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
                     .build();
             return new SoundPool.Builder()
                     .setAudioAttributes(attrs)
@@ -242,6 +254,7 @@ public class WrappedSoundPool extends Player {
 
     @SuppressWarnings("deprecation")
     private static SoundPool unsafeBuildLegacySoundPool() {
+        // TODO change to use earpiece
         return new SoundPool(1, AudioManager.STREAM_MUSIC, 1);
     }
 

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
@@ -237,12 +237,8 @@ public class WrappedSoundPool extends Player {
     private static SoundPool createSoundPool() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             AudioAttributes attrs = new AudioAttributes
-                    .Builder()
-                    .setLegacyStreamType(AudioManager.USE_DEFAULT_STREAM_TYPE)
-//                    .setLegacyStreamType(AudioManager.STREAM_VOICE_CALL)
+                    .Builder().setLegacyStreamType(AudioManager.USE_DEFAULT_STREAM_TYPE)
                     .setUsage(AudioAttributes.USAGE_GAME)
-//                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
-//                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
                     .build();
             return new SoundPool.Builder()
                     .setAudioAttributes(attrs)
@@ -254,7 +250,6 @@ public class WrappedSoundPool extends Player {
 
     @SuppressWarnings("deprecation")
     private static SoundPool unsafeBuildLegacySoundPool() {
-        // TODO change to use earpiece
         return new SoundPool(1, AudioManager.STREAM_MUSIC, 1);
     }
 

--- a/example/lib/player_widget.dart
+++ b/example/lib/player_widget.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 enum PlayerState { stopped, playing, paused }
+enum PlayingRouteState { speakers, earpiece }
 
 class PlayerWidget extends StatefulWidget {
   final String url;
@@ -28,6 +29,7 @@ class _PlayerWidgetState extends State<PlayerWidget> {
   Duration _position;
 
   PlayerState _playerState = PlayerState.stopped;
+  PlayingRouteState _playingRouteState = PlayingRouteState.speakers;
   StreamSubscription _durationSubscription;
   StreamSubscription _positionSubscription;
   StreamSubscription _playerCompleteSubscription;
@@ -38,6 +40,9 @@ class _PlayerWidgetState extends State<PlayerWidget> {
   get _isPaused => _playerState == PlayerState.paused;
   get _durationText => _duration?.toString()?.split('.')?.first ?? '';
   get _positionText => _position?.toString()?.split('.')?.first ?? '';
+
+  get _isPlayingThroughEarpiece =>
+      _playingRouteState == PlayingRouteState.earpiece;
 
   _PlayerWidgetState(this.url, this.mode);
 
@@ -81,6 +86,14 @@ class _PlayerWidgetState extends State<PlayerWidget> {
                 iconSize: 64.0,
                 icon: Icon(Icons.stop),
                 color: Colors.cyan),
+            IconButton(
+                onPressed: _earpieceOrSpeakersToggle,
+                iconSize: 64.0,
+                icon: _isPlayingThroughEarpiece
+                    ? Icon(Icons.volume_up)
+                    : Icon(Icons.hearing)
+                ,
+                color:  Colors.cyan),
           ],
         ),
         Column(
@@ -176,6 +189,8 @@ class _PlayerWidgetState extends State<PlayerWidget> {
       if (!mounted) return;
       setState(() => _audioPlayerState = state);
     });
+
+    _playingRouteState = PlayingRouteState.speakers;
   }
 
   Future<int> _play() async {
@@ -199,6 +214,16 @@ class _PlayerWidgetState extends State<PlayerWidget> {
   Future<int> _pause() async {
     final result = await _audioPlayer.pause();
     if (result == 1) setState(() => _playerState = PlayerState.paused);
+    return result;
+  }
+
+  Future<int> _earpieceOrSpeakersToggle() async {
+    final result = await _audioPlayer.earpieceOrSpeakersToggle();
+    if (result == 1)
+      setState(() => _playingRouteState =
+          _playingRouteState == PlayingRouteState.speakers
+              ? PlayingRouteState.earpiece
+              : PlayingRouteState.speakers);
     return result;
   }
 

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -620,7 +620,6 @@ class AudioPlayer {
         ? PlayingRouteState.SPEAKERS
         : PlayingRouteState.EARPIECE;
 
-//    return _invokeMethod('setVolume', {'volume': volume});
     final playingRouteName = playingRoute == PlayingRouteState.EARPIECE
         ? 'earpiece'
         : 'speakers';


### PR DESCRIPTION
# Description
Feature to toggle between speakers and earpiece. Can be used to play some thing when no headphones nearby and for not disturbing people around. Switch to headphones if connected (wire and wireless).

# Affected methods and callbacks:
1. Added `Content` into a methods `play`, `setUrl` of class `Player`
2. Added `Content` into `setAttributes` of class `WrappedMediaPlayer`
3. Added condition to choose between speakers and earpiece into `setAttributes` of class `WrappedMediaPlayer`
4. Added method `setPlayingRoute` into class `Player`
5. Added implementation of `setPlayingRoute` into `WrappedMediaPlayer`
6. Added new method `handleMethodCall` in to `AudioplayersPlugin` class
7. Added example

# Supporting platforms 
Implemented only for Android

# Tested
- Android v.10 google pixel
- Android v.10 API 29 emulator
- Android v.4.3.1 API 18 emulator
