### PR TITLE
Fix restarting the playback of a failed AVPlayerItem on iOS

### DIFF
--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -462,7 +462,9 @@ const float _defaultPlaybackRate = 1.0;
       [[AVAudioSession sharedInstance] setActive:YES error:&error];
   #endif
     
-  if (!playerInfo || ![url isEqualToString:playerInfo[@"url"]]) {
+    BOOL playbackFailed = ([[player currentItem] status] == AVPlayerItemStatusFailed);
+    
+  if (!playerInfo || ![url isEqualToString:playerInfo[@"url"]] || playbackFailed) {
     if (isLocal) {
       playerItem = [ [ AVPlayerItem alloc ] initWithURL:[ NSURL fileURLWithPath:url ]];
     } else {

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -462,7 +462,7 @@ const float _defaultPlaybackRate = 1.0;
       [[AVAudioSession sharedInstance] setActive:YES error:&error];
   #endif
     
-    BOOL playbackFailed = ([[player currentItem] status] == AVPlayerItemStatusFailed);
+  BOOL playbackFailed = ([[player currentItem] status] == AVPlayerItemStatusFailed);
     
   if (!playerInfo || ![url isEqualToString:playerInfo[@"url"]] || playbackFailed) {
     if (isLocal) {


### PR DESCRIPTION
This pull request fixes the restart of a failed AVPlayerItem on iOS

Steps to reproduce (I'm using remote URLs playback):
- play one of the URLs
- turn off the internet connection
- switch to the next URL
- the plugin would correctly report the playback failed
- attempt to restart the playback of the same URL

**Expected result:**
- if the device has the Internet connection, the playback restarts
- if the device has no Internet connection, the error is reported again

**Actual result:**
- nothing happens, the file doesn't play and the error is not reported as well