### PR TITLE
[iOS] switch between speakers and earpiece

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [next]
+- Implemented stream routing for iOS
 
 ## audioplayers 0.15.1
 - Fix web for release mode

--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ Toggle between speakers and earpiece.
 int result = await player.earpieceOrSpeakersToggle();
 ```
 
- :warning: **iOS stream routing not implemented**
-
 ### Streams
 
 Note: streams are not available on web yet.

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -55,6 +55,7 @@ NSString *_artist;
 NSString *_imageUrl;
 int _duration;
 const float _defaultPlaybackRate = 1.0;
+const NSString _defaultPlayingRoute = "speakers";
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   _registrar = registrar;
@@ -294,7 +295,7 @@ const float _defaultPlaybackRate = 1.0;
 -(void) initPlayerInfo: (NSString *) playerId {
   NSMutableDictionary * playerInfo = players[playerId];
   if (!playerInfo) {
-    players[playerId] = [@{@"isPlaying": @false, @"volume": @(1.0), @"rate": @(_defaultPlaybackRate), @"looping": @(false)} mutableCopy];
+    players[playerId] = [@{@"isPlaying": @false, @"volume": @(1.0), @"rate": @(_defaultPlaybackRate), @"looping": @(false), @"playingRoute": @(_defaultPlayingRoute)} mutableCopy];
   }
 }
 

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -468,7 +468,8 @@ const NSString *_defaultPlayingRoute = @"speakers";
       }
       
       if ([playerInfo[@"playingRoute"] isEqualToString:@"earpiece"]) {
-        success = [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+        // Use earpiece speaker to play audio.
+        success = [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
       }
 
       if (!success) {
@@ -671,11 +672,16 @@ const NSString *_defaultPlayingRoute = @"speakers";
   NSLog(@"%@ -> calling setPlayingRoute", osName);
   NSMutableDictionary *playerInfo = players[playerId];
   [playerInfo setObject:(playingRoute) forKey:@"playingRoute"];
-  
+
+  NSError *error = nil;
   if ([playingRoute isEqualToString:@"earpiece"]) {
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+    // Use earpiece speaker to play audio.
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
   } else {
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error];
+  }
+  if (!success) {
+    NSLog(@"Error setting playing route: %@", error);
   }
 } 
 

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -55,7 +55,7 @@ NSString *_artist;
 NSString *_imageUrl;
 int _duration;
 const float _defaultPlaybackRate = 1.0;
-const NSString _defaultPlayingRoute = "speakers";
+const NSString *_defaultPlayingRoute = @"speakers";
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   _registrar = registrar;
@@ -272,7 +272,7 @@ const NSString _defaultPlayingRoute = "speakers";
                     NSString *releaseMode = call.arguments[@"releaseMode"];
                     bool looping = [releaseMode hasSuffix:@"LOOP"];
                     [self setLooping:looping playerId:playerId];
-                  }
+                  },
                 @"earpieceOrSpeakersToggle":
                   ^{
                     NSLog(@"earpieceOrSpeakersToggle");
@@ -295,7 +295,7 @@ const NSString _defaultPlayingRoute = "speakers";
 -(void) initPlayerInfo: (NSString *) playerId {
   NSMutableDictionary * playerInfo = players[playerId];
   if (!playerInfo) {
-    players[playerId] = [@{@"isPlaying": @false, @"volume": @(1.0), @"rate": @(_defaultPlaybackRate), @"looping": @(false), @"playingRoute": @(_defaultPlayingRoute)} mutableCopy];
+    players[playerId] = [@{@"isPlaying": @false, @"volume": @(1.0), @"rate": @(_defaultPlaybackRate), @"looping": @(false), @"playingRoute": _defaultPlayingRoute} mutableCopy];
   }
 }
 
@@ -466,7 +466,7 @@ const NSString _defaultPlayingRoute = "speakers";
       } else {
         success = [[AVAudioSession sharedInstance] setCategory:category error:&error];
       }
-    
+
     if ([playerInfo[@"playingRoute"] isEqualToString:@"earpiece"]) {
         success = [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
       }
@@ -670,7 +670,7 @@ const NSString _defaultPlayingRoute = "speakers";
                playerId: (NSString *) playerId {
   NSLog(@"%@ -> calling setPlayingRoute", osName);
   NSMutableDictionary *playerInfo = players[playerId];
-  [playerInfo setObject:@(playingRoute) forKey:@"playingRoute"]
+  [playerInfo setObject:(playingRoute) forKey:@"playingRoute"];
 } 
 
 -(void) stop: (NSString *) playerId {

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -466,8 +466,8 @@ const NSString *_defaultPlayingRoute = @"speakers";
       } else {
         success = [[AVAudioSession sharedInstance] setCategory:category error:&error];
       }
-
-    if ([playerInfo[@"playingRoute"] isEqualToString:@"earpiece"]) {
+      
+      if ([playerInfo[@"playingRoute"] isEqualToString:@"earpiece"]) {
         success = [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
       }
 
@@ -671,6 +671,12 @@ const NSString *_defaultPlayingRoute = @"speakers";
   NSLog(@"%@ -> calling setPlayingRoute", osName);
   NSMutableDictionary *playerInfo = players[playerId];
   [playerInfo setObject:(playingRoute) forKey:@"playingRoute"];
+  
+  if ([playingRoute isEqualToString:@"earpiece"]) {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+  } else {
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+  }
 } 
 
 -(void) stop: (NSString *) playerId {

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -467,6 +467,10 @@ const NSString _defaultPlayingRoute = "speakers";
         success = [[AVAudioSession sharedInstance] setCategory:category error:&error];
       }
     
+    if ([playerInfo[@"playingRoute"] isEqualToString:@"earpiece"]) {
+        success = [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+      }
+
       if (!success) {
         NSLog(@"Error setting speaker: %@", error);
       }

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -661,6 +661,13 @@ const float _defaultPlaybackRate = 1.0;
   [playerInfo setObject:@(looping) forKey:@"looping"];
 }
 
+-(void) setPlayingRoute: (NSString *) playingRoute
+               playerId: (NSString *) playerId {
+  NSLog(@"%@ -> calling setPlayingRoute", osName);
+  NSMutableDictionary *playerInfo = players[playerId];
+  [playerInfo setObject:@(playingRoute) forKey:@"playingRoute"]
+} 
+
 -(void) stop: (NSString *) playerId {
   NSMutableDictionary * playerInfo = players[playerId];
 

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -673,12 +673,13 @@ const NSString *_defaultPlayingRoute = @"speakers";
   NSMutableDictionary *playerInfo = players[playerId];
   [playerInfo setObject:(playingRoute) forKey:@"playingRoute"];
 
+  BOOL success = false;
   NSError *error = nil;
   if ([playingRoute isEqualToString:@"earpiece"]) {
     // Use earpiece speaker to play audio.
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
+    success = [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
   } else {
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error];
+    success = [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error];
   }
   if (!success) {
     NSLog(@"Error setting playing route: %@", error);

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -272,6 +272,12 @@ const float _defaultPlaybackRate = 1.0;
                     bool looping = [releaseMode hasSuffix:@"LOOP"];
                     [self setLooping:looping playerId:playerId];
                   }
+                @"earpieceOrSpeakersToggle":
+                  ^{
+                    NSLog(@"earpieceOrSpeakersToggle");
+                    NSString *playingRoute = call.arguments[@"playingRoute"];
+                    [self setPlayingRoute:playingRoute playerId:playerId];
+                  }
                 };
 
   [ self initPlayerInfo:playerId ];


### PR DESCRIPTION
Issue numbers #429 and #389.

Implemented stream routing for iOS. Now able to switch between the main speaker and the earpiece speaker. 