### PR TITLE
Sound now plays on locked iOS device (fixes #526)

### DIFF
--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -458,6 +458,7 @@ const float _defaultPlaybackRate = 1.0;
         success = [[AVAudioSession sharedInstance] setCategory:category withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
       } else {
         success = [[AVAudioSession sharedInstance] setCategory:category error:&error];
+        [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
       }
     
       if (!success) {


### PR DESCRIPTION
On my tests with an iPhone 6, using AudioCache, no sound started to play after device was locked. 

Adding this one line fixed it:
```
        [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
```

Hope it can get merged! Thanks a lot for your great work!