### PR TITLE
Remove deprecated iOS device from build pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,6 @@ jobs:
     strategy:
       matrix:
         device:
-        - "iPhone 8 (13.3)"
         - "iPhone 11 Pro Max (13.3)"
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails.
       fail-fast: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         device:
-        - "iPhone 11 Pro Max (13.3)"
+        - "iPhone 11 Pro (13.4.1)"
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails.
       fail-fast: false
     runs-on: macOS-latest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         device:
-        - "iPhone 11 Pro Max (13.3)"
+        - "iPhone 11 Pro (13.4.1)"
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails.
       fail-fast: false
     runs-on: macOS-latest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -68,7 +68,6 @@ jobs:
     strategy:
       matrix:
         device:
-        - "iPhone 8 (13.3)"
         - "iPhone 11 Pro Max (13.3)"
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails.
       fail-fast: false


### PR DESCRIPTION
This should fix the build that has been broken for a few days.