### PR TITLE
remove assets prefix

### DIFF
--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -57,7 +57,7 @@ class AudioCache {
   }
 
   Future<ByteData> _fetchAsset(String fileName) async {
-    return await rootBundle.load('assets/$prefix$fileName');
+    return await rootBundle.load('$prefix$fileName');
   }
 
   Future<File> fetchToMemory(String fileName) async {


### PR DESCRIPTION
When we deliver the audioplayers with a flutter package, the hardcode assets path will conflict with package path.

Please read the explanation below.

Normally, we give the advancedPlayer a relative path.

```
await advancedPlayer
        .play("media/sound.mp3");
```

But in a flutter package we need to give it a fullpath

```
await advancedPlayer
        .play("packages/package_name/assets/media/sound.mp3");
```

