### PR TITLE
Allow audio ducking

### DIFF
--- a/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
+++ b/android/src/main/java/xyz/luan/audioplayers/AudioplayersPlugin.java
@@ -76,7 +76,8 @@ public class AudioplayersPlugin implements MethodCallHandler, FlutterPlugin {
                 final boolean respectSilence = call.argument("respectSilence");
                 final boolean isLocal = call.argument("isLocal");
                 final boolean stayAwake = call.argument("stayAwake");
-                player.configAttributes(respectSilence, stayAwake, context.getApplicationContext());
+                final boolean duckAudio = call.argument("duckAudio");
+                player.configAttributes(respectSilence, stayAwake, duckAudio, context.getApplicationContext());
                 player.setVolume(volume);
                 player.setUrl(url, isLocal, context.getApplicationContext());
                 if (position != null && !mode.equals("PlayerMode.LOW_LATENCY")) {

--- a/android/src/main/java/xyz/luan/audioplayers/Player.java
+++ b/android/src/main/java/xyz/luan/audioplayers/Player.java
@@ -23,7 +23,7 @@ abstract class Player {
 
     abstract int setRate(double rate);
 
-    abstract void configAttributes(boolean respectSilence, boolean stayAwake, Context context);
+    abstract void configAttributes(boolean respectSilence, boolean stayAwake, boolean duckAudio, Context context);
 
     abstract void setReleaseMode(ReleaseMode releaseMode);
 

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
@@ -359,7 +359,6 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
                 break;
             default:
                 extraMsg = whatMsg = "MEDIA_ERROR_UNKNOWN {extra:" + extra + "}";
-                ;
         }
         ref.handleError(this, "MediaPlayer error with what:" + whatMsg + " extra:" + extraMsg);
         return false;

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedMediaPlayer.java
@@ -4,12 +4,13 @@ import android.content.Context;
 import android.media.AudioAttributes;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
+import android.media.AudioFocusRequest;
 import android.os.Build;
 import android.os.PowerManager;
 
 import java.io.IOException;
 
-public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPreparedListener, MediaPlayer.OnCompletionListener, MediaPlayer.OnSeekCompleteListener, MediaPlayer.OnErrorListener {
+public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPreparedListener, MediaPlayer.OnCompletionListener, AudioManager.OnAudioFocusChangeListener, MediaPlayer.OnSeekCompleteListener, MediaPlayer.OnErrorListener {
 
     private String playerId;
 
@@ -18,17 +19,21 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
     private float rate = 1.0f;
     private boolean respectSilence;
     private boolean stayAwake;
+    private boolean duckAudio;
     private ReleaseMode releaseMode = ReleaseMode.RELEASE;
     private String playingRoute = "speakers";
 
     private boolean released = true;
     private boolean prepared = false;
     private boolean playing = false;
+    private Context context;
 
     private int shouldSeekTo = -1;
 
     private MediaPlayer player;
     private AudioplayersPlugin ref;
+    private AudioManager.OnAudioFocusChangeListener audioFocusChangeListener;
+    private AudioFocusRequest audioFocusRequest;
 
     WrappedMediaPlayer(AudioplayersPlugin ref, String playerId) {
         this.ref = ref;
@@ -114,9 +119,16 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
     }
 
     @Override
-    void configAttributes(boolean respectSilence, boolean stayAwake, Context context) {
+    void configAttributes(boolean respectSilence, boolean stayAwake, boolean duckAudio, Context context) {
+        this.context = context;
         if (this.respectSilence != respectSilence) {
             this.respectSilence = respectSilence;
+            if (!this.released) {
+                setAttributes(player, context);
+            }
+        }
+        if (this.duckAudio != duckAudio) {
+            this.duckAudio = duckAudio;
             if (!this.released) {
                 setAttributes(player, context);
             }
@@ -126,6 +138,13 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
             if (!this.released && this.stayAwake) {
                 this.player.setWakeMode(context, PowerManager.PARTIAL_WAKE_LOCK);
             }
+        }
+    }
+
+    @Override
+    public void onAudioFocusChange(int focusChange) {
+        if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
+            actuallyPlay(context);
         }
     }
 
@@ -168,7 +187,45 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
      */
 
     @Override
-    void play(Context context) {
+    @SuppressWarnings("deprecation")
+    void play(final Context context) {
+        this.context = context;
+        if (this.duckAudio) {
+            AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                audioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+                        .setAudioAttributes(
+                                new AudioAttributes.Builder()
+                                        .setUsage(respectSilence ? AudioAttributes.USAGE_NOTIFICATION_RINGTONE : AudioAttributes.USAGE_MEDIA)
+                                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                                        .build()
+                        )
+                        .setOnAudioFocusChangeListener(new AudioManager.OnAudioFocusChangeListener() {
+                            @Override
+                            public void onAudioFocusChange(int focusChange) {
+                                actuallyPlay(context);
+                            }
+                        }).build();
+                audioManager.requestAudioFocus(audioFocusRequest);
+            } else {
+                // Request audio focus for playback
+                int result = audioManager.requestAudioFocus(audioFocusChangeListener,
+                        // Use the music stream.
+                        AudioManager.STREAM_MUSIC,
+                        // Request permanent focus.
+                        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
+
+                if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+                    actuallyPlay(context);
+                }
+            }
+        } else {
+            actuallyPlay(context);
+        }
+    }
+
+    void actuallyPlay(Context context) {
         if (!this.playing) {
             this.playing = true;
             if (this.released) {
@@ -184,7 +241,19 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     void stop() {
+        if (this.duckAudio) {
+            AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                audioManager.abandonAudioFocusRequest(audioFocusRequest);
+            } else {
+                audioManager.abandonAudioFocus(audioFocusChangeListener);
+            }
+        }
+
         if (this.released) {
             return;
         }
@@ -216,6 +285,7 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
         this.prepared = false;
         this.released = true;
         this.playing = false;
+        this.context = null;
     }
 
     @Override
@@ -288,7 +358,8 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
                 extraMsg = "MEDIA_ERROR_TIMED_OUT";
                 break;
             default:
-                extraMsg = whatMsg = "MEDIA_ERROR_UNKNOWN {extra:" + extra + "}";;
+                extraMsg = whatMsg = "MEDIA_ERROR_UNKNOWN {extra:" + extra + "}";
+                ;
         }
         ref.handleError(this, "MediaPlayer error with what:" + whatMsg + " extra:" + extraMsg);
         return false;
@@ -328,19 +399,19 @@ public class WrappedMediaPlayer extends Player implements MediaPlayer.OnPrepared
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             if (objectEquals(this.playingRoute, "speakers")) {
                 player.setAudioAttributes(new AudioAttributes.Builder()
-                    .setUsage(respectSilence ? AudioAttributes.USAGE_NOTIFICATION_RINGTONE : AudioAttributes.USAGE_MEDIA)
-                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-                    .build()
+                        .setUsage(respectSilence ? AudioAttributes.USAGE_NOTIFICATION_RINGTONE : AudioAttributes.USAGE_MEDIA)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .build()
                 );
             } else {
                 // Works with bluetooth headphones
                 // automatically switch to earpiece when disconnect bluetooth headphones
                 player.setAudioAttributes(new AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
-                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-                    .build()
+                        .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .build()
                 );
-                if ( context != null ) {
+                if (context != null) {
                     AudioManager mAudioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
                     mAudioManager.setSpeakerphoneOn(false);
                 }

--- a/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
+++ b/android/src/main/java/xyz/luan/audioplayers/WrappedSoundPool.java
@@ -198,7 +198,7 @@ public class WrappedSoundPool extends Player {
     }
 
     @Override
-    void configAttributes(boolean respectSilence, boolean setWakeMode, Context context) {
+    void configAttributes(boolean respectSilence, boolean setWakeMode, boolean duckAudio, Context context) {
     }
 
     @Override

--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -35,7 +35,16 @@ class AudioCache {
   /// Not implemented on macOS.
   bool respectSilence;
 
-  AudioCache({this.prefix = "", this.fixedPlayer, this.respectSilence = false});
+  /// This flag should be set to true, if player is used for playing sound while there may be music
+  ///
+  /// If not set, the audio will be paused while playing on iOS and continue playing on Android.
+  bool duckAudio;
+
+  AudioCache(
+      {this.prefix = "",
+      this.fixedPlayer,
+      this.respectSilence = false,
+      this.duckAudio = false});
 
   /// Clears the cache of the file [fileName].
   ///
@@ -99,15 +108,16 @@ class AudioCache {
       {double volume = 1.0,
       bool isNotification,
       PlayerMode mode = PlayerMode.MEDIA_PLAYER,
-      bool stayAwake}) async {
+      bool stayAwake,
+      bool duckAudio}) async {
     String url = await getAbsoluteUrl(fileName);
     AudioPlayer player = _player(mode);
-    await player.play(
-      url,
-      volume: volume,
-      respectSilence: isNotification ?? respectSilence,
-      stayAwake: stayAwake,
-    );
+
+    await player.play(url,
+        volume: volume,
+        respectSilence: isNotification ?? respectSilence,
+        stayAwake: stayAwake,
+        duckAudio: duckAudio);
     return player;
   }
 

--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -36,7 +36,9 @@ class AudioCache {
   bool respectSilence;
 
   /// This flag should be set to true, if player is used for playing sound while there may be music
-  ///
+  /// 
+  /// Default to false
+  /// 
   /// If not set, the audio will be paused while playing on iOS and continue playing on Android.
   bool duckAudio;
 

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -371,6 +371,7 @@ class AudioPlayer {
     Duration position,
     bool respectSilence = false,
     bool stayAwake = false,
+    bool duckAudio = false,
   }) async {
     isLocal ??= isLocalUrl(url);
     volume ??= 1.0;
@@ -384,6 +385,7 @@ class AudioPlayer {
       'position': position?.inMilliseconds,
       'respectSilence': respectSilence,
       'stayAwake': stayAwake,
+      'duckAudio': duckAudio,
     });
 
     if (result == 1) {


### PR DESCRIPTION
This is a rework of #257 with asked reviews and a few more tweaks:

### Android

- I use (deprecated) `AudioManager.requestAudioFocus()` so we don't need to update minSdk to 26 (Android O). This triggers a warning during build that I suppressed with an annotation.
- This should work on android O too with conditionnal focus handling
- I kept the respectSilence audioAttribute
- I used `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` so external sound will continue after sound ended

### iOS
No changes made

If you have any question/reviews, tell me :) 
