### PR TITLE
Fixes #614

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,9 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    dependencies {
+        implementation 'androidx.annotation:annotation:1.1.0'
+    }
 }
 
 allprojects {


### PR DESCRIPTION
Fixes the following error when building using `flutter build apk`:

`error: cannot find symbol import androidx.annotation.NonNull;`