### PR TITLE
added release mode setting to play method.

### DIFF
--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -112,6 +112,7 @@ class AudioCache {
   }) async {
     String url = await getAbsoluteUrl(fileName);
     AudioPlayer player = _player(mode);
+    player.setReleaseMode(ReleaseMode.STOP);
     await player.play(
       url,
       volume: volume,


### PR DESCRIPTION
### Summary
In my research, I suspect that the cause is probably that I haven't set `player.setReleaseMode(ReleaseMode.STOP);` before processing player.play in this play method.

So I set the release mode STOP before playing.

This is a bug of the case where `fixedPlayer` is set in `AudioCache`.

I interacted with the developers on the issue page.

https://github.com/luanpotter/audioplayers/issues/618

