### PR TITLE
Add recordingActive option to setUrl

### DIFF
--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -532,10 +532,14 @@ class AudioPlayer {
   ///
   /// respectSilence is not implemented on macOS.
   Future<int> setUrl(String url,
-      {bool isLocal: false, bool respectSilence = false}) {
+      {bool isLocal: false, bool respectSilence = false, bool recordingActive = false}) {
     isLocal = isLocalUrl(url);
-    return _invokeMethod('setUrl',
-        {'url': url, 'isLocal': isLocal, 'respectSilence': respectSilence});
+    return _invokeMethod('setUrl', {
+      'url': url,
+      'isLocal': isLocal ?? false,
+      'respectSilence': respectSilence ?? false,
+      'recordingActive': recordingActive ?? false,
+    });
   }
 
   /// Get audio duration after setting url.

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -532,7 +532,9 @@ class AudioPlayer {
   ///
   /// respectSilence is not implemented on macOS.
   Future<int> setUrl(String url,
-      {bool isLocal: false, bool respectSilence = false, bool recordingActive = false}) {
+      {bool isLocal: false,
+      bool respectSilence = false,
+      bool recordingActive = false}) {
     isLocal = isLocalUrl(url);
     return _invokeMethod('setUrl', {
       'url': url,


### PR DESCRIPTION
In our use case, we need to have the `recordingActive` option to `setUrl`, which is currently only available with `play`, not to break our coexistent microphone feature.

BTW, `play` seemed to have a better way of passing parameters to the native layers so that I've derived it for `setUrl`.