### PR TITLE
[iOS fix] Do not disable the shared audio session—it breaks multiple players

### DIFF
--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -824,7 +824,6 @@ recordingActive: (bool) recordingActive
 
   [ _channel_audioplayer invokeMethod:@"audio.onComplete" arguments:@{@"playerId": playerId}];
   NSError *error = nil;
-    [[AVAudioSession sharedInstance] setActive:NO error:&error];
   #if TARGET_OS_IPHONE
       if (headlessServiceInitialized) {
           [_callbackChannel invokeMethod:@"audio.onNotificationBackgroundPlayerStateChanged" arguments:@{@"playerId": playerId, @"updateHandleMonitorKey": @(_updateHandleMonitorKey), @"value": @"completed"}];

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -838,7 +838,6 @@ recordingActive: (bool) recordingActive
     [[AVAudioSession sharedInstance] setActive:NO error:&error];
   }
 
-  NSError *error = nil;
   #if TARGET_OS_IPHONE
       if (headlessServiceInitialized) {
           [_callbackChannel invokeMethod:@"audio.onNotificationBackgroundPlayerStateChanged" arguments:@{@"playerId": playerId, @"updateHandleMonitorKey": @(_updateHandleMonitorKey), @"value": @"completed"}];

--- a/darwin/Classes/AudioplayersPlugin.m
+++ b/darwin/Classes/AudioplayersPlugin.m
@@ -823,6 +823,21 @@ recordingActive: (bool) recordingActive
   }
 
   [ _channel_audioplayer invokeMethod:@"audio.onComplete" arguments:@{@"playerId": playerId}];
+
+  BOOL hasPlaying = NO;
+
+  for (NSDictionary *playerInfo in [players allValues]) {
+    if ([playerInfo[@"isPlaying"] boolValue]) {
+      hasPlaying = YES;
+      break;
+    }
+  }
+
+  if (!hasPlaying) {
+    NSError *error = nil;
+    [[AVAudioSession sharedInstance] setActive:NO error:&error];
+  }
+
   NSError *error = nil;
   #if TARGET_OS_IPHONE
       if (headlessServiceInitialized) {


### PR DESCRIPTION
https://github.com/luanpotter/audioplayers/blob/3f580954e9ae8b04660ca1c02fdadfa1225888ee/darwin/Classes/AudioplayersPlugin.m#L827

The above line causes this warning to appear in logs:

> [avas]     AVAudioSession_iOS.mm:1150  Deactivating an audio session that has running I/O. All I/O should be stopped or paused prior to deactivating the audio session.

The reason is that this is the _shared_ audio session, used by all instances of `AudioPlayer` on the Flutter side. In my app, longer sounds were being interrupted after the completion of shorter sounds played in parallel, and this line was the cause.

This pull request prevents us from deactivating the audio session unless other sounds have finished playing.