### PR TITLE
Extract all the notifications code and make it optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [next]
+* Extracted and refactored all the notifications code onto the new file
+* Add more checks and make sure notifcations code is not ran when it shouldn't
 
 ## 0.17.0
 - Swift conversion of the darwin code

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -181,7 +181,7 @@ class WrappedMediaPlayer {
 
         reference.maybeDeactivateAudioSession()
         reference.onComplete(playerId: playerId)
-        reference.onNotificationBackgroundPlayerStateChanged(playerId: playerId, value: "completed")
+        reference.notificationsHandler?.onNotificationBackgroundPlayerStateChanged(playerId: playerId, value: "completed")
     }
     
     func onTimeInterval(time: CMTime) {
@@ -196,7 +196,6 @@ class WrappedMediaPlayer {
         guard let duration = player?.currentItem?.asset.duration else {
             return
         }
-        log("%@ -> updateDuration...%f", osName, CMTimeGetSeconds(duration))
         if CMTimeGetSeconds(duration) > 0 {
             let millis = fromCMTime(time: duration)
             reference.onDuration(playerId: playerId, millis: millis)


### PR DESCRIPTION
This:

* Extracts the remainder of the notifications code onto the new file, making it more separate than the rest of the code.
* Add more checks and make sure it is not ran on macos or if startHeadlessService is not called, which solves issues like these:
* * https://stackoverflow.com/questions/61263458/flutter-fatal-error-callback-lookup-failed-with-audioplayers-package
* * https://github.com/flame-engine/flame/issues/488
* Unified more of the compile time macros, the less compile time branching we have the better.