### PR TITLE
Add kotlin-gradle-plugin at android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,7 @@ group 'xyz.luan.audioplayers'
 version '1.0-SNAPSHOT'
 
 buildscript {
+    ext.kotlin_version = '1.4.21'
     repositories {
         google()
         jcenter()
@@ -9,6 +10,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -46,7 +48,6 @@ allprojects {
 }
 dependencies {
     implementation "androidx.core:core-ktx:+"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {
     mavenCentral()

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.20'
+    ext.kotlin_version = '1.4.21'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Thanks for the great library!

---

fix #718 

- Add `$kotlin_version` and `kotlin-gradle-plugin` at `android/build.gradle`
- Remove stdlib library from dependency block 
  - ref <https://kotlinlang.org/docs/reference/whatsnew14.html#dependency-on-the-standard-library-added-by-default>
- Update Kotlin 1.4.21
  - <https://github.com/JetBrains/kotlin/releases/tag/v1.4.21>