### PR TITLE
Fix misconfiguration

### DIFF
--- a/darwin/Classes/SwiftAudioplayersPlugin.swift
+++ b/darwin/Classes/SwiftAudioplayersPlugin.swift
@@ -128,8 +128,8 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             let volume: Float = (args["volume"] as? Float) ?? 1.0
             
             // we might or might not want to seek
-            let seekTimeMillis: Int? = (args["position"] as? Int)
-            let seekTime: CMTime? = seekTimeMillis.map { toCMTime(millis: $0) }
+            let seekTimeMillis: Int = (args["position"] as? Int) ?? 0
+            let seekTime: CMTime = toCMTime(millis: seekTimeMillis)
             
             let respectSilence: Bool = (args["respectSilence"] as? Bool) ?? false
             let recordingActive: Bool = (args["recordingActive"] as? Bool) ?? false
@@ -330,7 +330,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
         let hasPlaying = players.values.contains { player in player.isPlaying }
         if !hasPlaying {
             #if os(iOS)
-            configureAudioSession(active: true)
+            configureAudioSession(active: false)
             #endif
         }
     }


### PR DESCRIPTION
Hi, I found two code mistakes.

---

The default value of the seek position has changed.
Therefore, it can be played only once.

https://github.com/luanpotter/audioplayers/blob/98281f612f42b351b5cfe94f5dc66e24026d801e/darwin/Classes/SwiftAudioplayersPlugin.swift#L237

https://github.com/luanpotter/audioplayers/blob/cda8c39a01a0e6a0cd53f9c9ba515efc1c518c05/darwin/Classes/AudioplayersPlugin.m#L171

---

The session is not deactivated.

https://github.com/luanpotter/audioplayers/pull/710/files#diff-f48d6c32c3c16cb98ecc2514598b0c3eeff787b78ff213b2aa5960ee647c384cL346-L361

```swift
     func maybeDeactivateAudioSession() {
         let hasPlaying = players.values.contains { player in player.isPlaying }
         if !hasPlaying {
-            setAudioSessionActive(active: false)
-        }
-    }
-    
-    func setAudioSessionActive(active: Bool) {
-        #if os(iOS)
-        do {
-            try AVAudioSession.sharedInstance().setActive(active)
-        } catch {
-            log("Error inactivating audio session %@", error)
+            configureAudioSession(active: true)
         }
-        #endif
     }
```

https://github.com/luanpotter/audioplayers/blob/cda8c39a01a0e6a0cd53f9c9ba515efc1c518c05/darwin/Classes/AudioplayersPlugin.m#L838

```objective-c
  for (NSDictionary *playerInfo in [players allValues]) {
    if ([playerInfo[@"isPlaying"] boolValue]) {
      hasPlaying = YES;
      break;
    }
  }

  if (!hasPlaying) {
    NSError *error = nil;
    [[AVAudioSession sharedInstance] setActive:NO error:&error];
  }
```

---

This change has affected since v0.17.0.
Maybe, this pr is related #671.