### PR TITLE
Cleanup gradle file and imports

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,10 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 28
 
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+
     defaultConfig {
         minSdkVersion 23
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,9 +38,6 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
-    dependencies {
-        implementation 'androidx.annotation:annotation:1.1.0'
-    }
 }
 
 allprojects {
@@ -49,10 +46,4 @@ allprojects {
             options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
         }
     }
-}
-dependencies {
-    implementation "androidx.core:core-ktx:+"
-}
-repositories {
-    mavenCentral()
 }

--- a/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -7,12 +7,9 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import java.lang.IllegalArgumentException
 import java.lang.ref.WeakReference
 import java.util.logging.Level
 import java.util.logging.Logger
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
 
 class AudioplayersPlugin : MethodCallHandler, FlutterPlugin {
     private lateinit var channel: MethodChannel

--- a/android/src/main/kotlin/xyz/luan/audioplayers/ByteDataSource.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/ByteDataSource.kt
@@ -1,8 +1,6 @@
 package xyz.luan.audioplayers
 
 import android.media.MediaDataSource
-import java.io.IOException
-import kotlin.jvm.Throws
 
 class ByteDataSource(
         private val data: ByteArray

--- a/android/src/main/kotlin/xyz/luan/audioplayers/Player.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/Player.kt
@@ -1,6 +1,5 @@
 package xyz.luan.audioplayers
 
-import android.content.Context
 import android.media.MediaDataSource
 
 abstract class Player {

--- a/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
@@ -5,7 +5,9 @@ import android.media.AudioManager
 import android.media.MediaDataSource
 import android.media.SoundPool
 import android.util.Log
-import java.io.*
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
 import java.net.URI
 import java.net.URL
 import java.util.*


### PR DESCRIPTION
When I checked the android codes to investigate #767 comments, I found some points.

- Add sourceSets to search Kotlin files by Gradle
- Remote unused dependencies
- Optimize imports