### PR TITLE
Fix iOS Lockscreen Skip Intervals

### DIFF
--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -140,7 +140,7 @@ class WrappedMediaPlayer {
             log("Cannot skip forward, unable to determine maxDuration")
             return
         }
-        let newTime = CMTimeAdd(currentTime, toCMTime(millis: interval))
+        let newTime = CMTimeAdd(currentTime, toCMTime(seconds: interval))
         
         // if CMTime is more than max duration, limit it
         let clampedTime = CMTimeGetSeconds(newTime) > CMTimeGetSeconds(maxDuration) ? maxDuration : newTime
@@ -153,7 +153,7 @@ class WrappedMediaPlayer {
             return
         }
         
-        let newTime = CMTimeSubtract(currentTime, toCMTime(millis: interval))
+        let newTime = CMTimeSubtract(currentTime, toCMTime(seconds: interval))
         // if CMTime is negative, set it to zero
         let clampedTime = CMTimeGetSeconds(newTime) < 0 ? toCMTime(millis: 0) : newTime
         


### PR DESCRIPTION
This is a fix for https://github.com/luanpotter/audioplayers/issues/801

Skipping forward and back 30 seconds using the in-app controls works well through the seek method:
```dart
_player.seek(_position.inSeconds + 30)
```
However after setting the iOS lock screen controls via:
```dart
_player.setNotification(
  title: 'Test Audio',
  forwardSkipInterval: Duration(seconds: 30),
  backwardSkipInterval: Duration(seconds: 30),
  duration: Duration(seconds: duration),
  elapsedTime: Duration.zero,
);
```
The lock screen controls move the position forward and backward by **30 milliseconds instead of 30 seconds**.

This simple fix passes the interval as `seconds` instead of `millis`.