### PR TITLE
Make urls non-nullable on android

### DIFF
--- a/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -44,7 +44,7 @@ class AudioplayersPlugin : MethodCallHandler, FlutterPlugin {
         val player = getPlayer(playerId, mode)
         when (call.method) {
             "play" -> {
-                val url = call.argument<String>("url")
+                val url = call.argument<String>("url") !!
                 val isLocal = call.argument<Boolean>("isLocal") ?: false
 
                 val volume = call.argument<Double>("volume") ?: 1.0
@@ -90,7 +90,7 @@ class AudioplayersPlugin : MethodCallHandler, FlutterPlugin {
                 player.setVolume(volume)
             }
             "setUrl" -> {
-                val url = call.argument<String>("url")
+                val url = call.argument<String>("url") !!
                 val isLocal = call.argument<Boolean>("isLocal") ?: false
                 player.setUrl(url, isLocal)
             }

--- a/android/src/main/kotlin/xyz/luan/audioplayers/Player.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/Player.kt
@@ -15,7 +15,7 @@ abstract class Player {
     abstract fun pause()
 
     abstract fun configAttributes(respectSilence: Boolean, stayAwake: Boolean, duckAudio: Boolean)
-    abstract fun setUrl(url: String?, isLocal: Boolean)
+    abstract fun setUrl(url: String, isLocal: Boolean)
     abstract fun setDataSource(mediaDataSource: MediaDataSource?)
     abstract fun setVolume(volume: Double)
     abstract fun setRate(rate: Double)

--- a/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
@@ -30,8 +30,8 @@ class WrappedMediaPlayer internal constructor(
     /**
      * Setter methods
      */
-    override fun setUrl(url: String?, isLocal: Boolean) {
         if (this.url != url) {
+    override fun setUrl(url: String, isLocal: Boolean) {
             this.url = url
             val player = getOrCreatePlayer()
             player.setDataSource(url)


### PR DESCRIPTION
Since the dart API is has a non-nullable url string, we can do the same in kotlin.