### PR TITLE
Fix Cannot access built-in declaration 'kotlin.String'. Ensure that you have a dependency on the Kotlin standard library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,3 +47,11 @@ allprojects {
         }
     }
 }
+
+dependencies {
+    implementation "androidx.core:core-ktx:+"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}
+repositories {
+    mavenCentral()
+}


### PR DESCRIPTION
Closes https://github.com/luanpotter/audioplayers/issues/790