### PR TITLE
iOS Lock Screen Skip Fix Update

### DIFF
--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -140,7 +140,7 @@ class WrappedMediaPlayer {
             log("Cannot skip forward, unable to determine maxDuration")
             return
         }
-        let newTime = CMTimeAdd(currentTime, toCMTime(seconds: interval))
+        let newTime = CMTimeAdd(currentTime, toCMTime(millis: interval * 1000))
         
         // if CMTime is more than max duration, limit it
         let clampedTime = CMTimeGetSeconds(newTime) > CMTimeGetSeconds(maxDuration) ? maxDuration : newTime
@@ -153,7 +153,7 @@ class WrappedMediaPlayer {
             return
         }
         
-        let newTime = CMTimeSubtract(currentTime, toCMTime(seconds: interval))
+        let newTime = CMTimeSubtract(currentTime, toCMTime(millis: interval * 1000))
         // if CMTime is negative, set it to zero
         let clampedTime = CMTimeGetSeconds(newTime) < 0 ? toCMTime(millis: 0) : newTime
         

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -140,7 +140,7 @@ class WrappedMediaPlayer {
             log("Cannot skip forward, unable to determine maxDuration")
             return
         }
-        let newTime = CMTimeAdd(currentTime, toCMTime(millis: interval))
+        let newTime = CMTimeAdd(currentTime, toCMTime(seconds: interval))
         
         // if CMTime is more than max duration, limit it
         let clampedTime = CMTimeGetSeconds(newTime) > CMTimeGetSeconds(maxDuration) ? maxDuration : newTime
@@ -153,7 +153,7 @@ class WrappedMediaPlayer {
             return
         }
         
-        let newTime = CMTimeSubtract(currentTime, toCMTime(millis: interval))
+        let newTime = CMTimeSubtract(currentTime, toCMTime(seconds: interval))
         // if CMTime is negative, set it to zero
         let clampedTime = CMTimeGetSeconds(newTime) < 0 ? toCMTime(millis: 0) : newTime
         


### PR DESCRIPTION
The original fix caused an error by passing the interval as `seconds` - instead we should be passing as `millis` but multiplying by 1000 to achieve the correct skip time.