### PR TITLE
Initialize audioPlayerState with STOPPED

### DIFF
--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -41,7 +41,7 @@ enum ReleaseMode {
 
 /// Indicates the state of the audio player.
 enum AudioPlayerState {
-  /// Stop has been called or an error occurred.
+  /// initial state, stop has been called or an error occurred.
   STOPPED,
 
   /// Currently playing audio.
@@ -182,7 +182,7 @@ class AudioPlayer {
   /// Enables more verbose logging.
   static bool logEnabled = false;
 
-  late AudioPlayerState _audioPlayerState;
+  AudioPlayerState _audioPlayerState = AudioPlayerState.STOPPED;
 
   AudioPlayerState get state => _audioPlayerState;
 


### PR DESCRIPTION
I just ran into a runtime error, when I checked for the state before the player played anything:

```dart
        if (player.state == AudioPlayerState.PLAYING) {
          player.pause();
        } else {
          player.resume();
        }

```

Was there any reason for `late` to be used for the _audioPlayerState? If not, I think it should be initialized to `STOPPED`.