### PR TITLE
Refactor the Dart side notifications code and extract stuff into files

### DIFF
--- a/darwin/Classes/NotificationsHandler.swift
+++ b/darwin/Classes/NotificationsHandler.swift
@@ -132,14 +132,14 @@ class NotificationsHandler {
     static func geneateImageFromUrl(urlString: String) -> UIImage? {
         if urlString.hasPrefix("http") {
             guard let url: URL = URL.init(string: urlString) else {
-                log("Error download image url, invalid url %@", urlString)
+                Logger.log("Error download image url, invalid url %@", urlString)
                 return nil
             }
             do {
                 let data = try Data(contentsOf: url)
                 return UIImage.init(data: data)
             } catch {
-                log("Error download image url %@", error)
+                Logger.log("Error download image url %@", error)
                 return nil
             }
         } else {
@@ -164,7 +164,7 @@ class NotificationsHandler {
             MPNowPlayingInfoPropertyPlaybackRate: Float(playbackRate)
         ]
         
-        log("Updating playing info...")
+        Logger.log("Updating playing info...")
         
         // fetch notification image in async fashion to avoid freezing UI
         DispatchQueue.global().async() { [weak self] in
@@ -172,14 +172,14 @@ class NotificationsHandler {
                 let artworkImage: UIImage? = NotificationsHandler.geneateImageFromUrl(urlString: imageUrl)
                 if let artworkImage = artworkImage {
                     let albumArt: MPMediaItemArtwork = MPMediaItemArtwork.init(image: artworkImage)
-                    log("Will add custom album art")
+                    Logger.log("Will add custom album art")
                     playingInfo[MPMediaItemPropertyArtwork] = albumArt
                 }
             }
             
             if let infoCenter = self?.infoCenter {
                 let filteredMap = playingInfo.filter { $0.value != nil }.mapValues { $0! }
-                log("Setting playing info: %@", filteredMap)
+                Logger.log("Setting playing info: %@", filteredMap)
                 infoCenter.nowPlayingInfo = filteredMap
             }
         }
@@ -253,7 +253,7 @@ class NotificationsHandler {
     
     func skipBackwardEvent(skipEvent: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
         let interval = (skipEvent as! MPSkipIntervalCommandEvent).interval
-        log("Skip backward by %f", interval)
+        Logger.log("Skip backward by %f", interval)
         
         guard let player = reference.lastPlayer() else {
             return MPRemoteCommandHandlerStatus.commandFailed
@@ -265,7 +265,7 @@ class NotificationsHandler {
     
     func skipForwardEvent(skipEvent: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
         let interval = (skipEvent as! MPSkipIntervalCommandEvent).interval
-        log("Skip forward by %f", interval)
+        Logger.log("Skip forward by %f", interval)
         
         guard let player = reference.lastPlayer() else {
             return MPRemoteCommandHandlerStatus.commandFailed
@@ -324,7 +324,7 @@ class NotificationsHandler {
         }
         
         let positionTime = (changePositionEvent as! MPChangePlaybackPositionCommandEvent).positionTime
-        log("changePlaybackPosition to %f", positionTime)
+        Logger.log("changePlaybackPosition to %f", positionTime)
         let newTime = toCMTime(millis: positionTime)
         player.seek(time: newTime)
         return MPRemoteCommandHandlerStatus.success

--- a/darwin/Classes/SwiftAudioplayersPlugin.swift
+++ b/darwin/Classes/SwiftAudioplayersPlugin.swift
@@ -80,16 +80,16 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
         let method = call.method
         
         guard let args = call.arguments as? [String: Any] else {
-            log("Failed to parse call.arguments from Flutter.")
+            Logger.log("Failed to parse call.arguments from Flutter.")
             result(0)
             return
         }
         guard let playerId = args["playerId"] as? String else {
-            log("Call missing mandatory parameter playerId.")
+            Logger.log("Call missing mandatory parameter playerId.")
             result(0)
             return
         }
-        log("%@ => call %@, playerId %@", OS_NAME, method, playerId)
+        Logger.log("%@ => call %@, playerId %@", OS_NAME, method, playerId)
         
         let player = self.getOrCreatePlayer(playerId: playerId)
         
@@ -99,7 +99,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
                 return
             }
             if let handleKey = args["handleKey"] {
-                log("calling start headless service %@", handleKey)
+                Logger.log("calling start headless service %@", handleKey)
                 let handle = (handleKey as! [Any])[0]
                 handler.startHeadlessService(handle: (handle as! Int64))
             } else {
@@ -111,7 +111,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
                 return
             }
             if let handleMonitorKey = args["handleMonitorKey"] {
-                log("calling monitor notification %@", handleMonitorKey)
+                Logger.log("calling monitor notification %@", handleMonitorKey)
                 let handle = (handleMonitorKey as! [Any])[0]
                 handler.updateHandleMonitorKey(handle: handle as! Int64)
             } else {
@@ -119,7 +119,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             }
         } else if method == "play" {
             guard let url = args["url"] as! String? else {
-                log("Null url received on play")
+                Logger.log("Null url received on play")
                 result(0)
                 return
             }
@@ -158,7 +158,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
                 let time = toCMTime(millis: position)
                 player.seek(time: time)
             } else {
-                log("Null position received on seek")
+                Logger.log("Null position received on seek")
                 result(0)
             }
         } else if method == "setUrl" {
@@ -168,7 +168,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             let recordingActive: Bool = (args["recordingActive"] as? Bool) ?? false
             
             if url == nil {
-                log("Null URL received on setUrl")
+                Logger.log("Null URL received on setUrl")
                 result(0)
                 return
             }
@@ -188,7 +188,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             result(duration)
         } else if method == "setVolume" {
             guard let volume = args["volume"] as? Double else {
-                log("Error calling setVolume, volume cannot be null")
+                Logger.log("Error calling setVolume, volume cannot be null")
                 result(0)
                 return
             }
@@ -199,14 +199,14 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             result(currentPosition)
         } else if method == "setPlaybackRate" {
             guard let playbackRate = args["playbackRate"] as? Double else {
-                log("Error calling setPlaybackRate, playbackRate cannot be null")
+                Logger.log("Error calling setPlaybackRate, playbackRate cannot be null")
                 result(0)
                 return
             }
             player.setPlaybackRate(playbackRate: playbackRate)
         } else if method == "setReleaseMode" {
             guard let releaseMode = args["releaseMode"] as? String else {
-                log("Error calling setReleaseMode, releaseMode cannot be null")
+                Logger.log("Error calling setReleaseMode, releaseMode cannot be null")
                 result(0)
                 return
             }
@@ -214,13 +214,13 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
             player.looping = looping
         } else if method == "earpieceOrSpeakersToggle" {
             guard let playingRoute = args["playingRoute"] as? String else {
-                log("Error calling earpieceOrSpeakersToggle, playingRoute cannot be null")
+                Logger.log("Error calling earpieceOrSpeakersToggle, playingRoute cannot be null")
                 result(0)
                 return
             }
             self.setPlayingRoute(playerId: playerId, playingRoute: playingRoute)
         } else if method == "setNotification" {
-            log("setNotification called")
+            Logger.log("setNotification called")
             let title: String? = args["title"] as? String
             let albumTitle: String? = args["albumTitle"] as? String
             let artist: String? = args["artist"] as? String
@@ -253,7 +253,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
                 enableNextTrackButton: enableNextTrackButton
             )
         } else {
-            log("Called not implemented method: %@", method)
+            Logger.log("Called not implemented method: %@", method)
             result(FlutterMethodNotImplemented)
             return
         }
@@ -377,7 +377,7 @@ public class SwiftAudioplayersPlugin: NSObject, FlutterPlugin {
                 try session.setActive(active)
             }
         } catch {
-            log("Error configuring audio session: %@", error)
+            Logger.log("Error configuring audio session: %@", error)
         }
     }
     #endif

--- a/darwin/Classes/Utils.swift
+++ b/darwin/Classes/Utils.swift
@@ -1,6 +1,7 @@
 import AVKit
 
 class Logger {
+    // TODO(luan) wire this with the Dart side
     static var enableLogs = false
 
     static func log(_ items: Any...) {

--- a/darwin/Classes/Utils.swift
+++ b/darwin/Classes/Utils.swift
@@ -1,15 +1,24 @@
 import AVKit
 
-func log(_ items: Any...) {
-    let string: String
-    if items.count == 1, let s = items.first as? String {
-        string = s
-    } else if items.count > 1, let format = items.first as? String, let arguments = Array(items[1..<items.count]) as? [CVarArg] {
-        string = String(format: format, arguments: arguments)
-    } else {
-        string = ""
+class Logger {
+    static var enableLogs = false
+
+    static func log(_ items: Any...) {
+        if !enableLogs {
+            return
+        }
+
+        let string: String
+        if items.count == 1, let s = items.first as? String {
+            string = s
+        } else if items.count > 1, let format = items.first as? String, let arguments = Array(items[1..<items.count]) as? [CVarArg] {
+            string = String(format: format, arguments: arguments)
+        } else {
+            string = ""
+        }
+        
+        debugPrint(string)
     }
-    debugPrint(string)
 }
 
 func toCMTime(millis: Int) -> CMTime {

--- a/darwin/Classes/WrappedMediaPlayer.swift
+++ b/darwin/Classes/WrappedMediaPlayer.swift
@@ -133,11 +133,11 @@ class WrappedMediaPlayer {
     
     func skipForward(interval: TimeInterval) {
         guard let currentTime = getCurrentCMTime() else {
-            log("Cannot skip forward, unable to determine currentTime")
+            Logger.log("Cannot skip forward, unable to determine currentTime")
             return
         }
         guard let maxDuration = getDurationCMTime() else {
-            log("Cannot skip forward, unable to determine maxDuration")
+            Logger.log("Cannot skip forward, unable to determine maxDuration")
             return
         }
         let newTime = CMTimeAdd(currentTime, toCMTime(millis: interval * 1000))
@@ -148,7 +148,7 @@ class WrappedMediaPlayer {
     
     func skipBackward(interval: TimeInterval) {
         guard let currentTime = getCurrentCMTime() else {
-            log("Cannot skip forward, unable to determine currentTime")
+            Logger.log("Cannot skip forward, unable to determine currentTime")
             return
         }
         let newTime = CMTimeSubtract(currentTime, toCMTime(millis: interval * 1000))
@@ -254,7 +254,7 @@ class WrappedMediaPlayer {
             self.onReady = onReady
             let newKeyValueObservation = playerItem.observe(\AVPlayerItem.status) { (playerItem, change) in
                 let status = playerItem.status
-                log("player status: %@ change: %@", status, change)
+                Logger.log("player status: %@ change: %@", status, change)
                 
                 // Do something with the status...
                 if status == .readyToPlay {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,11 +3,13 @@ import 'dart:io';
 
 import 'package:audioplayers/audio_cache.dart';
 import 'package:audioplayers/audioplayers.dart';
+import 'package:audioplayers/player_mode.dart';
+import 'package:audioplayers/release_mode.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/src/foundation/constants.dart';
 import 'package:http/http.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter/src/foundation/constants.dart';
 
 import 'player_widget.dart';
 
@@ -40,8 +42,8 @@ class _ExampleAppState extends State<ExampleApp> {
       return;
     }
     if (Platform.isIOS) {
-      audioCache.fixedPlayer?.startHeadlessService();
-      advancedPlayer.startHeadlessService();
+      audioCache.fixedPlayer?.notificationService.startHeadlessService();
+      advancedPlayer.notificationService.startHeadlessService();
     }
   }
 

--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -7,6 +7,8 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:path_provider/path_provider.dart';
 
 import 'audioplayers.dart';
+import 'player_mode.dart';
+import 'release_mode.dart';
 
 /// This class represents a cache for Local Assets to be played.
 ///
@@ -62,13 +64,6 @@ class AudioCache {
       file.delete();
     }
     loadedFiles.clear();
-  }
-
-  /// Disables [AudioPlayer] logs (enable only if debugging, otherwise they can be quite overwhelming).
-  ///
-  /// TODO(luan) there are still some logs on the android native side that we could not get rid of, if you'd like to help, please send us a PR!
-  void disableLog() {
-    AudioPlayer.logEnabled = false;
   }
 
   Future<ByteData> _fetchAsset(String fileName) async {

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -65,22 +65,23 @@ class AudioPlayer {
 
   late NotificationService notificationService;
 
-  PlayerState _PlayerState = PlayerState.STOPPED;
+  PlayerState _playerState = PlayerState.STOPPED;
 
-  PlayerState get state => _PlayerState;
+  PlayerState get state => _playerState;
 
   set state(PlayerState state) {
     _playerStateController.add(state);
-    _PlayerState = state;
+    _playerState = state;
   }
 
   set playingRouteState(PlayingRoute routeState) {
     _playingRouteState = routeState;
   }
 
+  // TODO(luan) why do we need two methods for setting state?
   set notificationState(PlayerState state) {
     _notificationPlayerStateController.add(state);
-    _PlayerState = state;
+    _playerState = state;
   }
 
   /// Stream of changes on player state.
@@ -134,7 +135,7 @@ class AudioPlayer {
 
   /// Current mode of the audio player. Can be updated at any time, but is going
   /// to take effect only at the next time you play the audio.
-  PlayerMode mode;
+  final PlayerMode mode;
 
   /// Creates a new instance and assigns an unique id to it.
   AudioPlayer({this.mode = PlayerMode.MEDIA_PLAYER, String? playerId})
@@ -195,7 +196,7 @@ class AudioPlayer {
 
   /// Plays audio in the form of a byte array.
   ///
-  /// This is only supported on Android currently.
+  /// This is only supported on Android (SDK >= 23) currently.
   Future<int> playBytes(
     Uint8List bytes, {
     double volume = 1.0,
@@ -235,7 +236,7 @@ class AudioPlayer {
   /// If you call [resume] later, the audio will resume from the point that it
   /// has been paused.
   Future<int> pause() async {
-    final int result = await _invokeMethod('pause');
+    final result = await _invokeMethod('pause');
 
     if (result == 1) {
       state = PlayerState.PAUSED;
@@ -249,7 +250,7 @@ class AudioPlayer {
   /// The position is going to be reset and you will no longer be able to resume
   /// from the last point.
   Future<int> stop() async {
-    final int result = await _invokeMethod('stop');
+    final result = await _invokeMethod('stop');
 
     if (result == 1) {
       state = PlayerState.STOPPED;
@@ -261,7 +262,7 @@ class AudioPlayer {
   /// Resumes the audio that has been paused or stopped, just like calling
   /// [play], but without changing the parameters.
   Future<int> resume() async {
-    final int result = await _invokeMethod('resume');
+    final result = await _invokeMethod('resume');
 
     if (result == 1) {
       state = PlayerState.PLAYING;

--- a/lib/audioplayers_notifications.dart
+++ b/lib/audioplayers_notifications.dart
@@ -1,0 +1,155 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'player_state.dart';
+
+enum PlayerControlCommand {
+  NEXT_TRACK,
+  PREVIOUS_TRACK,
+}
+
+/// Note: this is an iOS only feature (so far). Does not work with android/
+/// web/macOS.
+///
+/// This bundles together all the notification related features from AP.
+class NotificationService {
+  /// Enable the notifications feature. This is a global toggle.
+  ///
+  /// Note: for best effects if you want to disable this, do it at the start
+  /// of your app.
+  /// TODO(luan) consider making this false by default.
+  static bool enableNotificationService = true;
+
+  final Future<void> Function(
+    String,
+    Map<String, dynamic>,
+  ) platformChannelInvoke;
+
+  NotificationService(this.platformChannelInvoke) {
+    if (enableNotificationService) {
+      startHeadlessService();
+    }
+  }
+
+  /// This should be called after initiating AudioPlayer only if you want to
+  /// listen for notification changes in the background.
+  ///
+  /// Only for iOS (not implemented on macOS, android, web)
+  Future<void> startHeadlessService() async {
+    return _callWithHandle(
+      'startHeadlessService',
+      _backgroundCallbackDispatcher,
+    );
+  }
+
+  /// Start getting significant audio updates through `callback`.
+  ///
+  /// `callback` is invoked on a background isolate and will not have direct
+  /// access to the state held by the main isolate (or any other isolate).
+  Future<void> monitorStateChanges(
+    void Function(PlayerState value) callback,
+  ) async {
+    return _callWithHandle('monitorNotificationStateChanges', callback);
+  }
+
+  /// Sets the notification bar for lock screen and notification area in iOS for now.
+  ///
+  /// At least the [title] is required.
+  Future<void> setNotification({
+    String title = '',
+    String albumTitle = '',
+    String artist = '',
+    String imageUrl = '',
+    Duration forwardSkipInterval = Duration.zero,
+    Duration backwardSkipInterval = Duration.zero,
+    Duration duration = Duration.zero,
+    Duration elapsedTime = Duration.zero,
+    bool enablePreviousTrackButton = false,
+    bool enableNextTrackButton = false,
+  }) async {
+    return _call('setNotification', {
+      'title': title,
+      'albumTitle': albumTitle,
+      'artist': artist,
+      'imageUrl': imageUrl,
+      'forwardSkipInterval': forwardSkipInterval.inSeconds,
+      'backwardSkipInterval': backwardSkipInterval.inSeconds,
+      'duration': duration.inSeconds,
+      'elapsedTime': elapsedTime.inSeconds,
+      'enablePreviousTrackButton': enablePreviousTrackButton,
+      'enableNextTrackButton': enableNextTrackButton,
+    });
+  }
+
+  Future<void> _callWithHandle(String methodName, Function callback) async {
+    return _call(methodName, {'handleKey': _getBgHandleKey(callback)});
+  }
+
+  Future<void> _call(String methodName, Map<String, dynamic> args) async {
+    if (!enableNotificationService) {
+      throw 'The notifications feature was disabled.';
+    }
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return;
+    }
+    await platformChannelInvoke(methodName, args);
+  }
+}
+
+List<dynamic> _getBgHandleKey(Function callback) {
+  final handle = PluginUtilities.getCallbackHandle(callback);
+  assert(handle != null, 'Unable to lookup callback.');
+  return <dynamic>[handle!.toRawHandle()];
+}
+
+/// When we start the background service isolate, we only ever enter it once.
+/// To communicate between the native plugin and this entrypoint, we'll use
+/// MethodChannels to open a persistent communication channel to trigger
+/// callbacks.
+void _backgroundCallbackDispatcher() {
+  const MethodChannel _channel =
+      MethodChannel('xyz.luan/audioplayers_callback');
+
+  // Setup Flutter state needed for MethodChannels.
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Reference to the onAudioChangeBackgroundEvent callback.
+  Function(PlayerState)? onAudioChangeBackgroundEvent;
+
+  // This is where the magic happens and we handle background events from the
+  // native portion of the plugin. Here we message the audio notification data
+  // which we then pass to the provided callback.
+  _channel.setMethodCallHandler((MethodCall call) async {
+    Function(PlayerState) _performCallbackLookup() {
+      final CallbackHandle handle = CallbackHandle.fromRawHandle(
+          call.arguments['updateHandleMonitorKey']);
+
+      // PluginUtilities.getCallbackFromHandle performs a lookup based on the
+      // handle we retrieved earlier.
+      final Function? closure = PluginUtilities.getCallbackFromHandle(handle);
+
+      if (closure == null) {
+        print('Fatal Error: Callback lookup failed!');
+      }
+      return closure as Function(PlayerState);
+    }
+
+    final Map<dynamic, dynamic> callArgs = call.arguments as Map;
+    if (call.method == 'audio.onNotificationBackgroundPlayerStateChanged') {
+      onAudioChangeBackgroundEvent ??= _performCallbackLookup();
+      final String playerState = callArgs['value'];
+      if (playerState == 'playing') {
+        onAudioChangeBackgroundEvent!(PlayerState.PLAYING);
+      } else if (playerState == 'paused') {
+        onAudioChangeBackgroundEvent!(PlayerState.PAUSED);
+      } else if (playerState == 'completed') {
+        onAudioChangeBackgroundEvent!(PlayerState.COMPLETED);
+      }
+    } else {
+      assert(false, "No handler defined for method type: '${call.method}'");
+    }
+  });
+}

--- a/lib/audioplayers_web.dart
+++ b/lib/audioplayers_web.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:audioplayers/audioplayers.dart';
+import 'package:audioplayers/release_mode.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 

--- a/lib/player_mode.dart
+++ b/lib/player_mode.dart
@@ -1,0 +1,16 @@
+/// This enum is meant to be used as a parameter of the [AudioPlayer]'s
+/// constructor. It represents the general mode of the [AudioPlayer].
+///
+// In iOS and macOS, both modes have the same backend implementation.
+enum PlayerMode {
+  /// Ideal for long media files or streams.
+  MEDIA_PLAYER,
+
+  /// Ideal for short audio files, since it reduces the impacts on visuals or
+  /// UI performance.
+  ///
+  /// In this mode the backend won't fire any duration or position updates.
+  /// Also, it is not possible to use the seek method to set the audio a
+  /// specific position.
+  LOW_LATENCY
+}

--- a/lib/player_mode.dart
+++ b/lib/player_mode.dart
@@ -12,5 +12,5 @@ enum PlayerMode {
   /// In this mode the backend won't fire any duration or position updates.
   /// Also, it is not possible to use the seek method to set the audio a
   /// specific position.
-  LOW_LATENCY
+  LOW_LATENCY,
 }

--- a/lib/player_state.dart
+++ b/lib/player_state.dart
@@ -1,0 +1,14 @@
+/// Indicates the state of the audio player.
+enum PlayerState {
+  /// initial state, stop has been called or an error occurred.
+  STOPPED,
+
+  /// Currently playing audio.
+  PLAYING,
+
+  /// Pause has been called.
+  PAUSED,
+
+  /// The audio successfully completed (reached the end).
+  COMPLETED,
+}

--- a/lib/playing_route.dart
+++ b/lib/playing_route.dart
@@ -16,7 +16,7 @@ extension PlayingRouteExtensions on PlayingRoute {
     }
   }
 
-  /// Note: this only makes sense because we have exactly two playing routes.EARPIECE
+  /// Note: this only makes sense because we have exactly two playing routes.
   /// If that ever was to change, this method would need to be removed.
   PlayingRoute toggle() {
     switch (this) {

--- a/lib/playing_route.dart
+++ b/lib/playing_route.dart
@@ -6,6 +6,7 @@ enum PlayingRoute {
 
 extension PlayingRouteExtensions on PlayingRoute {
   /// Returns this enum name to be used over the wire with the native side.
+  /// TODO(luan) other enums use toString(), we should unify.
   String name() {
     switch (this) {
       case PlayingRoute.SPEAKERS:

--- a/lib/playing_route.dart
+++ b/lib/playing_route.dart
@@ -1,0 +1,28 @@
+/// Indicates which speakers use for playing
+enum PlayingRoute {
+  SPEAKERS,
+  EARPIECE,
+}
+
+extension PlayingRouteExtensions on PlayingRoute {
+  /// Returns this enum name to be used over the wire with the native side.
+  String name() {
+    switch (this) {
+      case PlayingRoute.SPEAKERS:
+        return 'speakers';
+      case PlayingRoute.EARPIECE:
+        return 'earpiece';
+    }
+  }
+
+  /// Note: this only makes sense because we have exactly two playing routes.EARPIECE
+  /// If that ever was to change, this method would need to be removed.
+  PlayingRoute toggle() {
+    switch (this) {
+      case PlayingRoute.SPEAKERS:
+        return PlayingRoute.EARPIECE;
+      case PlayingRoute.EARPIECE:
+        return PlayingRoute.SPEAKERS;
+    }
+  }
+}

--- a/lib/release_mode.dart
+++ b/lib/release_mode.dart
@@ -1,0 +1,24 @@
+/// This enum is meant to be used as a parameter of [setReleaseMode] method.
+///
+/// It represents the behaviour of [AudioPlayer] when an audio is finished or
+/// stopped.
+enum ReleaseMode {
+  /// Releases all resources, just like calling [release] method.
+  ///
+  /// In Android, the media player is quite resource-intensive, and this will
+  /// let it go. Data will be buffered again when needed (if it's a remote file,
+  /// it will be downloaded again).
+  /// In iOS and macOS, works just like [stop] method.
+  ///
+  /// This is the default behaviour.
+  RELEASE,
+
+  /// Keeps buffered data and plays again after completion, creating a loop.
+  /// Notice that calling [stop] method is not enough to release the resources
+  /// when this mode is being used.
+  LOOP,
+
+  /// Stops audio playback but keep all resources intact.
+  /// Use this if you intend to play again later.
+  STOP,
+}


### PR DESCRIPTION
**Note**: This is a small breaking change.

This is a followup to the first change on the iOS code where the notifications stuff was separated. This does the same on the dart side. I tried to keep this small while at the same time including some improvements.

---

Key changes:

* to avoid circular deps, I had to split the enums from the main audioplayers package. This is a breaking change but an extremely simple one that should not cause any issues. We should probably convert this to the new structure we use at Flame with the `src` folder and group export files, and also divide everything into federated packages, but I did not want to get into that in this PR (cc @renancaraujo).
* The namespace for the notification related methods on the Dart side was changed (for the better IMO).
* I wanna tackle the overabundant logs next, I included some small tweaks here already
* I added a global flag to completely disable the notifications feature: `NotificationService.enableNotificationService`. Looking at the code I believe some memory leaks we have on iOS might be because of this. Once this lands we should task force answering the many ios-resource-leak issues asking to set this to false. I want to set it to false by default in the future, but let's start small.
* I don't think our analysis_options has the good stuff. I noticed this mid-PR. I will update it and fix any minor lint issues everywhere on a followup. Speaking of which, do we now have a unified linter rule-set?

---

Build is green. Since this is relatively bigger change I am testing on every platform, but reviews are welcome.