### PR TITLE
Implement AudioCache for web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [next]
+- Refactor Notifications code (small breaking changes)
+- AudioCache for web
 
 ## 0.18.3
 - Fix Float vs Double mixup on Swift that prevent non-integer values for volume/playback

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -124,7 +124,7 @@ class _ExampleAppState extends State<ExampleApp> {
           _Btn(
             txt: 'Play',
             onPressed: () async {
-              var bytes = await (await audioCache.loadAsFile('audio.mp3'))
+              final bytes = await (await audioCache.loadAsFile('audio.mp3'))
                   .readAsBytes();
               audioCache.playBytes(bytes);
             },
@@ -135,7 +135,7 @@ class _ExampleAppState extends State<ExampleApp> {
           _Btn(
             txt: 'Loop',
             onPressed: () async {
-              var bytes = await (await audioCache.loadAsFile('audio.mp3'))
+              final bytes = await (await audioCache.loadAsFile('audio.mp3'))
                   .readAsBytes();
               audioCache.playBytes(bytes, loop: true);
             },
@@ -170,7 +170,7 @@ class _ExampleAppState extends State<ExampleApp> {
   }
 
   Future<int> _getDuration() async {
-    Uri uri = await audioCache.load('audio2.mp3');
+    final uri = await audioCache.load('audio2.mp3');
     await advancedPlayer.setUrl(uri.toString());
     int duration = await Future.delayed(
       Duration(seconds: 2),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,7 @@ class _ExampleAppState extends State<ExampleApp> {
   AudioCache audioCache = AudioCache();
   AudioPlayer advancedPlayer = AudioPlayer();
   String? localFilePath;
+  String? localAudioCacheURI;
 
   @override
   void initState() {
@@ -90,11 +91,27 @@ class _ExampleAppState extends State<ExampleApp> {
 
   Widget localFile() {
     return _Tab(children: [
+      Text(' -- manually load bytes (no web!) --'),
       Text('File: $kUrl1'),
       _Btn(txt: 'Download File to your Device', onPressed: () => _loadFile()),
       Text('Current local file path: $localFilePath'),
       localFilePath == null ? Container() : PlayerWidget(url: localFilePath!),
+      Container(
+        constraints: BoxConstraints.expand(width: 1.0, height: 20.0),
+      ),
+      Text(' -- via AudioCache --'),
+      Text('File: $kUrl2'),
+      _Btn(txt: 'Download File to your Device', onPressed: () => _loadFileAC()),
+      Text('Current AC loaded: $localAudioCacheURI'),
+      localAudioCacheURI == null
+          ? Container()
+          : PlayerWidget(url: localAudioCacheURI!),
     ]);
+  }
+
+  void _loadFileAC() async {
+    final uri = await audioCache.load(kUrl2);
+    setState(() => localAudioCacheURI = uri.toString());
   }
 
   Widget localAsset() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -107,8 +107,8 @@ class _ExampleAppState extends State<ExampleApp> {
           _Btn(
             txt: 'Play',
             onPressed: () async {
-              var bytes =
-                  await (await audioCache.load('audio.mp3')).readAsBytes();
+              var bytes = await (await audioCache.loadAsFile('audio.mp3'))
+                  .readAsBytes();
               audioCache.playBytes(bytes);
             },
           ),
@@ -118,8 +118,8 @@ class _ExampleAppState extends State<ExampleApp> {
           _Btn(
             txt: 'Loop',
             onPressed: () async {
-              var bytes =
-                  await (await audioCache.load('audio.mp3')).readAsBytes();
+              var bytes = await (await audioCache.loadAsFile('audio.mp3'))
+                  .readAsBytes();
               audioCache.playBytes(bytes, loop: true);
             },
           ),
@@ -153,10 +153,8 @@ class _ExampleAppState extends State<ExampleApp> {
   }
 
   Future<int> _getDuration() async {
-    File audiofile = await audioCache.load('audio2.mp3');
-    await advancedPlayer.setUrl(
-      audiofile.path,
-    );
+    Uri uri = await audioCache.load('audio2.mp3');
+    await advancedPlayer.setUrl(uri.toString());
     int duration = await Future.delayed(
       Duration(seconds: 2),
       () => advancedPlayer.getDuration(),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
     sdk: flutter
   audioplayers:
     path: ../
-  http: ^0.13.0
+  http: ^0.13.1
   path_provider: ^2.0.1
   path_provider_macos: ^2.0.0
   provider: 5.0.0

--- a/feature_parity_table.md
+++ b/feature_parity_table.md
@@ -23,8 +23,7 @@ Note: LLM means Low Latency Mode.
         <tr><td>byte array</td><td>SDK >=23</td><td>not yet</td><td>not yet</td><td>not yet</td></tr>
         <tr><td colspan="5"><strong>Audio Config</strong></td></tr>
         <tr><td>set url</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
-        <tr><td>pre-load</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td></tr>
-        <tr><td>audio cache</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td></tr>
+        <tr><td>audio cache (pre-load)</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
         <tr><td>low latency mode</td><td>SDK >=21</td><td>no</td><td>no</td><td>no</td></tr>
         <tr><td colspan="5"><strong>Audio Control Commands</strong></td></tr>
         <tr><td>resume / pause / stop</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>

--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -78,7 +78,7 @@ class AudioCache {
 
   Future<Uri> fetchToMemory(String fileName) async {
     if (kIsWeb) {
-      final uri = Uri.parse('assets/$prefix$fileName');
+      final uri = _sanitizeURLForWeb(fileName);
       // We relly on browser caching here. Once the browser downloads this file,
       // the native side implementation should be able to access it from cache.
       await http.get(uri);
@@ -95,6 +95,16 @@ class AudioCache {
 
     // returns the local file uri
     return file.uri;
+  }
+
+  Uri _sanitizeURLForWeb(String fileName) {
+    final tryAbsolute = Uri.tryParse(fileName);
+    if (tryAbsolute?.isAbsolute == true) {
+      return tryAbsolute!;
+    }
+
+    // local asset
+    return Uri.parse('assets/$prefix$fileName');
   }
 
   /// Loads a single [fileName] to the cache.

--- a/lib/audio_cache.dart
+++ b/lib/audio_cache.dart
@@ -63,7 +63,7 @@ class AudioCache {
   /// Clears the cache for the file [fileName].
   ///
   /// Does nothing if the file was not on cache.
-  /// Note: web relies on browser cache which is handled by entirely by the browser.
+  /// Note: web relies on browser cache which is handled entirely by the browser.
   Future<void> clear(Uri fileName) async {
     final uri = loadedFiles.remove(fileName);
     if (uri != null && !kIsWeb) {
@@ -79,7 +79,7 @@ class AudioCache {
   Future<Uri> fetchToMemory(String fileName) async {
     if (kIsWeb) {
       final uri = _sanitizeURLForWeb(fileName);
-      // We relly on browser caching here. Once the browser downloads this file,
+      // We rely on browser caching here. Once the browser downloads this file,
       // the native side implementation should be able to access it from cache.
       await http.get(uri);
       return uri;

--- a/lib/audioplayers_notifications.dart
+++ b/lib/audioplayers_notifications.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart' show defaultTargetPlatform;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -85,7 +85,16 @@ class NotificationService {
   }
 
   Future<void> _callWithHandle(String methodName, Function callback) async {
-    return _call(methodName, {'handleKey': _getBgHandleKey(callback)});
+    if (!enableNotificationService) {
+      throw 'The notifications feature was disabled.';
+    }
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return;
+    }
+    await platformChannelInvoke(
+      methodName,
+      {'handleKey': _getBgHandleKey(callback)},
+    );
   }
 
   Future<void> _call(String methodName, Map<String, dynamic> args) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -87,12 +87,12 @@ packages:
     source: sdk
     version: "0.0.0"
   http:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.13.1"
   http_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ flutter:
 dependencies:
   uuid: ^3.0.1
   path_provider: ^2.0.1
+  http: ^0.13.1
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/test/audio_cache_test.dart
+++ b/test/audio_cache_test.dart
@@ -13,9 +13,9 @@ class MyAudioCache extends AudioCache {
       : super(prefix: prefix, fixedPlayer: fixedPlayer);
 
   @override
-  Future<File> fetchToMemory(String fileName) async {
+  Future<Uri> fetchToMemory(String fileName) async {
     called.add(fileName);
-    return new File('test/assets/' + fileName);
+    return Uri.parse('test/assets/$fileName');
   }
 }
 


### PR DESCRIPTION
This is not my ideal implementation. I think in the ideal world we should use playBytes. but I tried looking into that for iOS and seemed very hard. So for now I believe this is a unified way to support all platforms. AFAIK subsequent requests on the browser are cached as expected.