### PR TITLE
Fixing basic features for Android lower than API 23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
 - Refactor Notifications code (small breaking changes)
 - AudioCache for web
+- Fixing basic features for Android lower than API 23
 
 ## 0.18.3
 - Fix Float vs Double mixup on Swift that prevent non-integer values for volume/playback

--- a/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
@@ -52,6 +52,8 @@ class WrappedMediaPlayer internal constructor(
                 player.setDataSource(mediaDataSource)
                 preparePlayer(player)
             }
+        } else {
+            throw RuntimeException("setDataSource is only available on API >= 23");
         }
     }
 

--- a/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
@@ -38,16 +38,20 @@ class WrappedMediaPlayer internal constructor(
             preparePlayer(player)
         }
 
-        // Dispose of any old data buffer array, if we are now playing from another source.
-        dataSource = null
+        if (Build.VERSION.SDK_INT >= 23) {
+            // Dispose of any old data buffer array, if we are now playing from another source.
+            dataSource = null
+        }
     }
 
     override fun setDataSource(mediaDataSource: MediaDataSource?) {
-        if (!objectEquals(dataSource, mediaDataSource)) {
-            dataSource = mediaDataSource
-            val player = getOrCreatePlayer()
-            player.setDataSource(mediaDataSource)
-            preparePlayer(player)
+        if (Build.VERSION.SDK_INT >= 23) {
+            if (!objectEquals(dataSource, mediaDataSource)) {
+                dataSource = mediaDataSource
+                val player = getOrCreatePlayer()
+                player.setDataSource(mediaDataSource)
+                preparePlayer(player)
+            }
         }
     }
 
@@ -109,7 +113,9 @@ class WrappedMediaPlayer internal constructor(
         this.rate = rate.toFloat()
 
         val player = this.player ?: return
-        player.playbackParams = player.playbackParams.setSpeed(this.rate)
+        if (Build.VERSION.SDK_INT >= 23) {
+            player.playbackParams = player.playbackParams.setSpeed(this.rate)
+        }
     }
 
     override fun configAttributes(respectSilence: Boolean, stayAwake: Boolean, duckAudio: Boolean) {
@@ -205,7 +211,7 @@ class WrappedMediaPlayer internal constructor(
             if (released || currentPlayer == null) {
                 released = false
                 player = createPlayer().also {
-                    if (dataSource != null) {
+                    if (Build.VERSION.SDK_INT >= 23 && dataSource != null) {
                         it.setDataSource(dataSource)
                     } else {
                         it.setDataSource(url)

--- a/feature_parity_table.md
+++ b/feature_parity_table.md
@@ -31,7 +31,7 @@ Note: LLM means Low Latency Mode.
         <tr><td>volume</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
         <tr><td>seek</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td></tr>
         <tr><td colspan="5"><strong>Advanced Audio Control Commands</strong></td></tr>
-        <tr><td>playback rate</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td></tr>
+        <tr><td>playback rate</td><td>SDK >= 23</td><td>yes</td><td>yes</td><td>not yet</td></tr>
         <tr><td>duck audio</td><td>yes (except LLM)</td><td>no</td><td>no</td><td>no</td></tr>
         <tr><td>respect silence</td><td>yes (except LLM)</td><td>yes</td><td>no</td><td>no</td></tr>
         <tr><td>stay awake</td><td>yes (except LLM)</td><td>yes</td><td>no</td><td>no</td></tr>


### PR DESCRIPTION
This PR re-enables the basic features of AudioPlayers on devices older than API 23

Fixes #829 