### PR TITLE
Added missing recordingActive parameter to dart side of plugin

### DIFF
--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -344,6 +344,7 @@ class AudioPlayer {
     String url, {
     bool? isLocal,
     bool respectSilence = false,
+    bool recordingActive = false,
   }) {
     return _invokeMethod(
       'setUrl',
@@ -351,6 +352,7 @@ class AudioPlayer {
         'url': url,
         'isLocal': isLocal ?? isLocalUrl(url),
         'respectSilence': respectSilence,
+        'recordingActive': recordingActive,
       },
     );
   }


### PR DESCRIPTION
I've just spotted that iOS side of the plugin supports "recordingActive" parameter for "setUrl" method (SwiftAudioplayersPlugin.swift:168)
Unfortunately it seems that currently its impossible to pass it via that method since dart implementation is missing it, so I added it (see my PR diff).