### PR TITLE
Fix audio_cache.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Flutter does not provide an easy way to play audio on your assets, but this clas
 
 It works as a cache because it keeps track of the copied files so that you can replay them without delay.
 
-You can find the full documentation for this class [here](packages/audioplayers/doc/audio_cache.md).
+You can find the full documentation for this class [here](https://github.com/luanpotter/audioplayers/blob/master/packages/audioplayers/doc/audio_cache.md).
 
 ### playerId
 


### PR DESCRIPTION
This works on github and on pub.dev

See: 
 * https://github.com/dart-lang/pub-dev/issues/4841
 * https://github.com/dart-lang/pub-dev/issues/4875

--------

Hint: using symlinks and such is not well supported...