### PR TITLE
Fixed local file playback in LOW_LATENCY mode on Android

### DIFF
--- a/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
+++ b/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
@@ -213,7 +213,11 @@ class WrappedSoundPool internal constructor(override val playerId: String) : Pla
     private fun loopModeInteger(): Int = if (looping) -1 else 0
 
     private fun getAudioPath(url: String?, isLocal: Boolean): String? {
-        return if (isLocal) url else loadTempFileFromNetwork(url).absolutePath
+        if (isLocal) {
+            return if (url?.startsWith("file://") == true) url!!.substring(7) else url
+        }
+
+        return loadTempFileFromNetwork(url).absolutePath
     }
 
     private fun loadTempFileFromNetwork(url: String?): File {


### PR DESCRIPTION
When playing a local file with PlayerMode.LOW_LATENCY, Android passed the path including "file://" to SoundPool, so it was fixed to remove "file://".