### PR TITLE
QUICKFIX Set Kotlin Core to v1.6.0

### DIFF
--- a/packages/audioplayers/android/build.gradle
+++ b/packages/audioplayers/android/build.gradle
@@ -49,7 +49,7 @@ allprojects {
 }
 
 dependencies {
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {


### PR DESCRIPTION
- FIX incompatible v1.7.0-alpha.

Please merge and release as a hotfix ASAP as this is a blocking issue. 
This PR fixes #926 and #923 