### PR TITLE
Fix: Fatal exception on Android API < 21 in WrappedMediaPlayer.kt setAttributes

### DIFF
--- a/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
+++ b/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
@@ -350,22 +350,30 @@ class WrappedMediaPlayer internal constructor(
     }
 
     private fun setAttributes(player: MediaPlayer) {
-        val usage = when {
-            // Works with bluetooth headphones
-            // automatically switch to earpiece when disconnect bluetooth headphones
-            playingRoute != "speakers" -> AudioAttributes.USAGE_VOICE_COMMUNICATION
-            respectSilence -> AudioAttributes.USAGE_NOTIFICATION_RINGTONE
-            else -> AudioAttributes.USAGE_MEDIA
-        }
-        player.setAudioAttributes(
-                AudioAttributes.Builder()
-                        .setUsage(usage)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-                        .build()
-        )
-
-        if (usage == AudioAttributes.USAGE_VOICE_COMMUNICATION) {
-            audioManager.isSpeakerphoneOn = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            val usage = when {
+                // Works with bluetooth headphones
+                // automatically switch to earpiece when disconnect bluetooth headphones
+                playingRoute != "speakers" -> AudioAttributes.USAGE_VOICE_COMMUNICATION
+                respectSilence -> AudioAttributes.USAGE_NOTIFICATION_RINGTONE
+                else -> AudioAttributes.USAGE_MEDIA
+            }
+            player.setAudioAttributes(
+                    AudioAttributes.Builder()
+                            .setUsage(usage)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                            .build()
+            )
+            if (usage == AudioAttributes.USAGE_VOICE_COMMUNICATION) {
+                audioManager.isSpeakerphoneOn = false
+            }
+        } else {
+            // This method is deprecated but must be used on older devices
+            if (playingRoute == "speakers") {
+                player.setAudioStreamType(if (respectSilence) AudioManager.STREAM_RING else AudioManager.STREAM_MUSIC)
+            } else {
+                player.setAudioStreamType(AudioManager.STREAM_VOICE_CALL)
+            }
         }
     }
 

--- a/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
+++ b/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
@@ -28,13 +28,20 @@ class WrappedSoundPool internal constructor(override val playerId: String) : Pla
         private val urlToPlayers = Collections.synchronizedMap(mutableMapOf<String, MutableList<WrappedSoundPool>>())
 
         private fun createSoundPool(): SoundPool {
-            val attrs = AudioAttributes.Builder().setLegacyStreamType(AudioManager.USE_DEFAULT_STREAM_TYPE)
-                    .setUsage(AudioAttributes.USAGE_GAME)
-                    .build()
-            return SoundPool.Builder()
-                    .setAudioAttributes(attrs)
-                    .setMaxStreams(100)
-                    .build()
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                val attrs = AudioAttributes.Builder().setLegacyStreamType(AudioManager.USE_DEFAULT_STREAM_TYPE)
+                        .setUsage(AudioAttributes.USAGE_GAME)
+                        .build()
+                // make a new SoundPool, allowing up to 100 streams
+                SoundPool.Builder()
+                        .setAudioAttributes(attrs)
+                        .setMaxStreams(100)
+                        .build()
+            } else {
+                // make a new SoundPool, allowing up to 100 streams
+                @Suppress("DEPRECATION")
+                SoundPool(100, AudioManager.STREAM_MUSIC, 0)
+            }
         }
 
         init {

--- a/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
+++ b/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
@@ -11,6 +11,7 @@ import java.io.FileOutputStream
 import java.net.URI
 import java.net.URL
 import java.util.*
+import android.os.Build
 
 class WrappedSoundPool internal constructor(override val playerId: String) : Player() {
     companion object {


### PR DESCRIPTION
fix a bug causing android devices below api < 21 to crash when:
final AudioCache audioCache = AudioCache(prefix: 'assets/audio/');
await audioCache.loadAll([<filenames>]);

audioCache.play(fileName);

