### PR TITLE
"clearCache" is switched to "clearAll" in documentation

### DIFF
--- a/packages/audioplayers/doc/audio_cache.md
+++ b/packages/audioplayers/doc/audio_cache.md
@@ -73,7 +73,7 @@ Finally, you can use the `clear` method to remove something from the cache:
     player.clear('explosion.mp3');
 ```
 
-There is also a `clearCache` method, that clears the whole cache.
+There is also a `clearAll` method, that clears the whole cache.
 
 This might be useful if, for instance, your game has multiple levels and each has a different soundtrack.
 


### PR DESCRIPTION
Currently the documentation says it is clearCache to remove everything from cache. But it should be clearAll in the latest version of AudioPlayers.