### PR TITLE
Make setPlaybackRate consistent with other setter methods

### DIFF
--- a/packages/audioplayers/example/lib/main.dart
+++ b/packages/audioplayers/example/lib/main.dart
@@ -430,7 +430,7 @@ class _AdvancedState extends State<Advanced> {
                   return _Btn(
                     txt: e.toString(),
                     onPressed: () {
-                      widget.advancedPlayer.setPlaybackRate(playbackRate: e);
+                      widget.advancedPlayer.setPlaybackRate(e);
                     },
                   );
                 }).toList(),

--- a/packages/audioplayers/example/lib/player_widget.dart
+++ b/packages/audioplayers/example/lib/player_widget.dart
@@ -230,11 +230,6 @@ class _PlayerWidgetState extends State<PlayerWidget> {
       setState(() => _playerState = PlayerState.PLAYING);
     }
 
-    // default playback rate is 1.0
-    // this should be called after _audioPlayer.play() or _audioPlayer.resume()
-    // this can also be called everytime the user wants to change playback rate in the UI
-    _audioPlayer.setPlaybackRate();
-
     return result;
   }
 

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -322,9 +322,8 @@ class AudioPlayer {
   /// Sets the playback rate - call this after first calling play() or resume().
   ///
   /// iOS and macOS have limits between 0.5 and 2x
-  /// Android SDK version should be 23 or higher.
-  /// not sure if that's changed recently.
-  Future<int> setPlaybackRate({double playbackRate = 1.0}) {
+  /// Android SDK version should be 23 or higher
+  Future<int> setPlaybackRate(double playbackRate) {
     return _invokeMethod(
       'setPlaybackRate',
       <String, dynamic>{


### PR DESCRIPTION
No point in having a named parameter in the setter. Also, the default value is not necessary; changing the playback rate from 1 to 1 changes nothing. If you have something to change it to, provide the value.